### PR TITLE
Resurrect decorators

### DIFF
--- a/examples/counter/App.js
+++ b/examples/counter/App.js
@@ -4,14 +4,16 @@ import { increment, decrement } from './actions/CounterActions';
 import counterStore from './stores/counterStore';
 import Counter from './Counter';
 
-@Root
-export default class App extends Component {
+export default class CounterApp extends Component {
   render() {
     return (
-      <Container stores={counterStore}
-                 actions={{ increment, decrement }}>
-        {props => <Counter {...props} />}
-      </Container>
+      <Root>
+        {() =>
+          <Container stores={counterStore} actions={{ increment, decrement }}>
+            {props => <Counter {...props} />}
+          </Container>
+        }
+      </Root>
     );
   }
 }

--- a/examples/todo/App.js
+++ b/examples/todo/App.js
@@ -5,19 +5,21 @@ import { Root, Container } from 'redux';
 import { todoStore } from './stores/index';
 import { addTodo } from './actions/index';
 
-@Root
-export default class App {
+export default class TodoApp {
   render() {
     return (
-      <Container stores={todoStore}
-                 actions={{ addTodo }}>
-        {props =>
-          <div>
-            <Header addTodo={props.addTodo} />
-            <Body todos={props.todos} />
-          </div>
+      <Root>
+        {() =>
+          <Container stores={todoStore} actions={{ addTodo }}>
+            {props =>
+              <div>
+                <Header addTodo={props.addTodo} />
+                <Body todos={props.todos} />
+              </div>
+            }
+          </Container>
         }
-      </Container>
+      </Root>
     );
   }
 }

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,23 +1,32 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import createDispatcher from './createDispatcher';
 
-export default function root(DecoratedComponent) {
-  return class ReduxRoot extends Component {
-    static childContextTypes = {
-      redux: PropTypes.object.isRequired
-    };
-
-    getChildContext() {
-      return { redux: this.dispatcher };
-    }
-
-    constructor(props, context) {
-      super(props, context);
-      this.dispatcher = createDispatcher();
-    }
-
-    render() {
-      return <DecoratedComponent {...this.props} />;
-    }
+export default class ReduxRoot {
+  static propTypes = {
+    children: PropTypes.func.isRequired
   };
+
+  static childContextTypes = {
+    redux: PropTypes.object.isRequired
+  };
+
+  constructor() {
+    this.dispatcher = createDispatcher();
+  }
+
+  getChildContext() {
+    const { observeStores, wrapActionCreator } = this.dispatcher
+    return {
+      redux: {
+        observeStores,
+        wrapActionCreator
+      }
+    };
+  }
+
+  render() {
+    return this.props.children({
+      ...this.props
+    });
+  }
 }

--- a/src/decorators/container.js
+++ b/src/decorators/container.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Container from '../Container';
+
+export default function container({ actions = {}, stores = [] }) {
+  return (DecoratedComponent) => {
+    return class ReduxContainerDecorator {
+      render() {
+        return (
+          <Container actions={actions} stores={stores}>
+            {props => <DecoratedComponent {...this.props} {...props} />}
+          </Container>
+        );
+      }
+    };
+  };
+}

--- a/src/decorators/root.js
+++ b/src/decorators/root.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Root from '../Root';
+
+export default function root(DecoratedComponent) {
+  return class ReduxRootDecorator {
+    render() {
+      return (
+        <Root>
+          {props => <DecoratedComponent {...props} />}
+        </Root>
+      );
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,7 @@
+// Higher-order components
 export Root from './Root';
 export Container from './Container';
+
+// Decorators
+export root from './decorators/root';
+export container from './decorators/container';


### PR DESCRIPTION
Bring back decorator APIs:

```js
import { container, root } from 'redux';

@root
class App {
  render() {
    return (
      <Counter />
    );
  }
}

@container({
  actions: { increment, decrement },
  stores: counterStore
})
class Counter {
  static propTypes = {
    increment: PropTypes.func.isRequired,
    decrement: PropTypes.func.isRequired,
    counter: PropTypes.number.isRequired
  };

  render() {
    const { increment, decrement, counter } = this.props;
    return (
      <p>
        Clicked: {counter} times
        {' '}
        <button onClick={() => increment()}>+</button>
        {' '}
        <button onClick={() => decrement()}>-</button>
      </p>
    );
  }
}
```