### PR TITLE
Allow children to be React element

### DIFF
--- a/src/addons/container.js
+++ b/src/addons/container.js
@@ -2,13 +2,13 @@ import React from 'react';
 import Container from '../Container';
 import getDisplayName from './getDisplayName';
 
-export default function container({ actions, stores }) {
+export default function container(options) {
   return (DecoratedComponent) => class ReduxContainerDecorator {
     static displayName = `ReduxContainer(${getDisplayName(DecoratedComponent)})`;
 
     render() {
       return (
-        <Container actions={actions} stores={stores}>
+        <Container {...options}>
           {props => <DecoratedComponent {...this.props} {...props} />}
         </Container>
       );


### PR DESCRIPTION
The following PR allows `ReduxContainer` to contain React elements.
It does not break compatibility.

```js
<Container {...opts} Wrapper={SomeFancyComponent}>
  <CounterRed />
  <CounterBlue />
</Container>
```

Feedback is welcomed :wink: 