### PR TITLE
Accept stores as an object of prop key to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ import {
 
 // but you can write this part anyhow you like:
 
-const initialState = { counter: 0 };
+const initialState = 0;
 
-function increment({ counter }) {
-  return { counter: counter + 1 };
+function increment(counter) {
+  return counter + 1;
 }
 
-function decrement({ counter }) {
-  return { counter: counter - 1 };
+function decrement(counter) {
+  return counter - 1;
 }
 
 // what's important is that Store is a pure function too
@@ -156,14 +156,13 @@ import Counter from './Counter';
 
 export default class CounterContainer {
   render() {
-    // stores must be an array.
-    // actions must be a string -> function map.
+    // stores and actions must both be string -> function maps.
     // props passed to children will combine these actions and state.
     return (
-      <Container stores={[counterStore]}
+      <Container stores={{ counter: stores.counterStore }}
                  actions={{ increment, decrement }}>
         {/* Yes this is a function as a child. Bear with me. */}
-        {props => <Counter {...props} />}
+        {({ state, actions }) => <Counter {...state} {...actions} />}
       </Container>
     );
   }
@@ -183,7 +182,7 @@ import counterStore from './stores/counterStore';
 
 @container({
   actions: { increment, decrement },
-  stores: [counterStore]
+  stores: { counter: counterStore }
 })
 export default class Counter {
   static propTypes = {

--- a/examples/counter/App.js
+++ b/examples/counter/App.js
@@ -8,9 +8,9 @@ import Counter from './Counter';
 export default class CounterApp extends Component {
   render() {
     return (
-      <Container stores={[stores.counterStore]}
+      <Container stores={{ counter: stores.counterStore }}
                  actions={{ increment, decrement }}>
-        {props => <Counter {...props} />}
+        {({ state, actions }) => <Counter {...state} {...actions} />}
       </Container>
     );
   }

--- a/examples/counter/stores/counterStore.js
+++ b/examples/counter/stores/counterStore.js
@@ -3,14 +3,14 @@ import {
   DECREMENT_COUNTER
 } from '../constants/ActionTypes';
 
-const initialState = { counter: 0 };
+const initialState = 0;
 
-function increment({ counter }) {
-  return { counter: counter + 1 };
+function increment(counter) {
+  return counter + 1;
 }
 
-function decrement({ counter }) {
-  return { counter: counter - 1 };
+function decrement(counter) {
+  return counter - 1;
 }
 
 export default function counterStore(state = initialState, action) {

--- a/examples/todo/Body.js
+++ b/examples/todo/Body.js
@@ -3,7 +3,7 @@ import { container } from 'redux';
 import { todoStore } from './stores/index';
 
 @container({
-  stores: [todoStore]
+  stores: { todos: todoStore }
 })
 export default class Body {
   static propTypes = {

--- a/examples/todo/stores/index.js
+++ b/examples/todo/stores/index.js
@@ -1,21 +1,17 @@
 import { ADD_TODO } from '../constants/ActionTypes';
 
-const initialState = {
-  todos: [{
-    text: 'do something',
-    id: 0
-  }]
-};
+const initialState = [{
+  text: 'do something',
+  id: 0
+}];
 
 export function todoStore(state = initialState, action) {
   switch (action.type) {
   case ADD_TODO:
-    return {
-      todos: [{
-        id: state.todos[0].id + 1,
-        text: action.text
-      }].concat(state.todos)
-    };
+    return [{
+      id: state[0].id + 1,
+      text: action.text
+    }].concat(state);
   }
 
   return state;

--- a/src/addons/container.js
+++ b/src/addons/container.js
@@ -2,14 +2,22 @@ import React from 'react';
 import Container from '../Container';
 import getDisplayName from './getDisplayName';
 
-export default function container({ actions, stores }) {
+function defaultTransformProps({ state, actions }) {
+  return { ...state, ...actions };
+}
+
+export default function container(
+  { actions, stores },
+  transformProps = defaultTransformProps
+) {
   return (DecoratedComponent) => class ReduxContainerDecorator {
     static displayName = `ReduxContainer(${getDisplayName(DecoratedComponent)})`;
 
     render() {
       return (
         <Container actions={actions} stores={stores}>
-          {props => <DecoratedComponent {...this.props} {...props} />}
+          {props => <DecoratedComponent {...this.props}
+                                        {...transformProps(props)} />}
         </Container>
       );
     }


### PR DESCRIPTION
This makes `stores` and `actions` symmetric and lets us specify custom
prop names easily.

`container` decorator now takes a second argument `transformProps`,
which is a function that is used to transform the state and actions
props before passing them to the component. It defaults to
`({ state, actions }) => ({ ...state, ...actions })`

I removed some nesting from the states of `counterStore` and `todoStore` examples, because it didn't seem necessary after this change and made prop passing simpler.

Fixes #22.