### PR TITLE
Allow to get action result

### DIFF
--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -120,10 +120,10 @@ export default function createDispatcher() {
       const action = actionCreator(...args);
       if (typeof action === 'function') {
         // Callback-style action creator
-        action(dispatch, currentState);
+        return action(dispatch, currentState);
       } else {
         // Simple action creator
-        dispatch(action);
+        return dispatch(action);
       }
     };
   }


### PR DESCRIPTION
I want to wait for an async action before React.renterToString on server. Example
```js
function fetchDataForHomePageActionCreator() {
  return async dispatch => {
    await timeout(100)
    dispatch({type: HOMEPAGE_DATA_LOADED})
  }
}

async function homepageHandler(request) {
  const dispatcher = createDispatcher()
  const prepare = dispatcher.wrapActionCreator(fetchDataForHomePageActionCreator)
  await prepare()
  return React.renderToString(<Dispatcher dispatcher={dispatcher}><HomePage /></Dispatcher>)
}
```