### PR TITLE
Add basic middleware api to default dispatcher

### DIFF
--- a/examples/actions/CounterActions.js
+++ b/examples/actions/CounterActions.js
@@ -7,7 +7,9 @@ export function increment() {
 }
 
 export function incrementIfOdd() {
-  return (dispatch, { counter }) => {
+  return (dispatch, getState) => {
+    const { counter } = getState();
+
     if (counter % 2 === 0) {
       return;
     }

--- a/examples/components/Counter.js
+++ b/examples/components/Counter.js
@@ -8,7 +8,7 @@ export default class Counter {
   };
 
   render() {
-    const { increment, decrement, counter } = this.props;
+    const { increment, incrementIfOdd, decrement, counter } = this.props;
     return (
       <p>
         Clicked: {counter} times
@@ -16,6 +16,8 @@ export default class Counter {
         <button onClick={increment}>+</button>
         {' '}
         <button onClick={decrement}>-</button>
+        {' '}
+        <button onClick={incrementIfOdd}>Increment if odd</button>
       </p>
     );
   }

--- a/src/Redux.js
+++ b/src/Redux.js
@@ -2,10 +2,13 @@ import createDispatcher from './createDispatcher';
 import composeStores from './utils/composeStores';
 
 export default class Redux {
-  constructor(dispatcher, initialState, middleware) {
+  constructor(dispatcher, initialState) {
     if (typeof dispatcher === 'object') {
       // A shortcut notation to use the default dispatcher
-      dispatcher = createDispatcher(composeStores(dispatcher), middleware);
+      dispatcher = createDispatcher(
+        composeStores(dispatcher),
+        [ ::this.middleware ]
+      );
     }
 
     this.state = initialState;
@@ -24,6 +27,15 @@ export default class Redux {
 
   dispatch(action) {
     return this.dispatchFn(action);
+  }
+
+  middleware(next) {
+    const recurse = (action) =>
+      typeof action === 'function' ?
+        action(recurse, ::this.getState) :
+        next(action);
+
+    return recurse;
   }
 
   getState() {

--- a/src/Redux.js
+++ b/src/Redux.js
@@ -2,10 +2,10 @@ import createDispatcher from './createDispatcher';
 import composeStores from './utils/composeStores';
 
 export default class Redux {
-  constructor(dispatcher, initialState) {
+  constructor(dispatcher, initialState, middleware) {
     if (typeof dispatcher === 'object') {
       // A shortcut notation to use the default dispatcher
-      dispatcher = createDispatcher(composeStores(dispatcher), initialState);
+      dispatcher = createDispatcher(composeStores(dispatcher), middleware);
     }
 
     this.state = initialState;

--- a/src/Redux.js
+++ b/src/Redux.js
@@ -1,5 +1,6 @@
 import createDispatcher from './createDispatcher';
 import composeStores from './utils/composeStores';
+import thunkMiddleware from './middleware/thunk';
 
 export default class Redux {
   constructor(dispatcher, initialState) {
@@ -7,7 +8,7 @@ export default class Redux {
       // A shortcut notation to use the default dispatcher
       dispatcher = createDispatcher(
         composeStores(dispatcher),
-        [ ::this.middleware ]
+        getState => [ thunkMiddleware(getState) ]
       );
     }
 
@@ -27,15 +28,6 @@ export default class Redux {
 
   dispatch(action) {
     return this.dispatchFn(action);
-  }
-
-  middleware(next) {
-    const recurse = (action) =>
-      typeof action === 'function' ?
-        action(recurse, ::this.getState) :
-        next(action);
-
-    return recurse;
   }
 
   getState() {

--- a/src/Redux.js
+++ b/src/Redux.js
@@ -5,7 +5,7 @@ export default class Redux {
   constructor(dispatcher, initialState) {
     if (typeof dispatcher === 'object') {
       // A shortcut notation to use the default dispatcher
-      dispatcher = createDispatcher(composeStores(dispatcher));
+      dispatcher = createDispatcher(composeStores(dispatcher), initialState);
     }
 
     this.state = initialState;

--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -1,20 +1,28 @@
-export default function createDispatcher(store) {
+export default function createDispatcher(store, middleware) {
   return function dispatcher(initialState, setState) {
     let state = store(initialState, {});
     setState(state);
 
-    function dispatchSync(action) {
+    function dispatch(action) {
       state = store(state, action);
       setState(state);
       return action;
     }
 
-    function dispatch(action) {
-      return typeof action === 'function' ?
-        action(dispatch, state) :
-        dispatchSync(action);
+    // Default middleware. It's special because it reads in the current state.
+    // This is kept here to maintain existing API behavior.
+    function perform(next) {
+      return function recurse(action) {
+        return typeof action === 'function' ?
+          action(recurse, state) :
+          next(action);
+      };
     }
 
-    return dispatch;
+    if (typeof middleware === 'undefined') {
+      middleware = perform;
+    }
+
+    return middleware(dispatch);
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,5 +11,6 @@ export provide from './components/provide';
 export connect from './components/connect';
 
 // Utilities
+export compose from './utils/composeMiddleware';
 export composeStores from './utils/composeStores';
 export bindActionCreators from './utils/bindActionCreators';

--- a/src/middleware/thunk.js
+++ b/src/middleware/thunk.js
@@ -1,0 +1,10 @@
+export default function thunkMiddleware(getState) {
+  return (next) => {
+    const recurse = (action) =>
+      typeof action === 'function' ?
+        action(recurse, getState) :
+        next(action);
+
+    return recurse;
+  };
+}

--- a/src/utils/composeMiddleware.js
+++ b/src/utils/composeMiddleware.js
@@ -1,0 +1,3 @@
+export default function compose(...middlewares) {
+  return middlewares.reduceRight((composed, m) => m(composed));
+}


### PR DESCRIPTION
This gives users the ability to pass global "action middleware" (terminology still in flux) to the default dispatcher.

```js
// Before
createRedux(stores, initialState);
// After
createRedux(stores, initialState, middleware);
```

## What is middleware?

Middleware is a function that wraps the `dispatch()` method, or another middleware. For example, to use a middleware:

```js
// Instead of this
dispatch(action)
// do this
middleware(dispatch)(action)
```

Multiple middleware can be composed manually

```js
middleware1(middleware2(dispatch))(action)
```

Or using the provided `compose()` utility:

```js
// All are equivalent:
middleware1(middleware2(dispatch))(action)
compose(middleware1, middleware2)(dispatch)(action)
compose(middleware1, middleware2, dispatch)(action)
```

The `compose()` middleware may seem trivial, but it makes it allows you to easily compose an array of middleware using spread notation:

```
compose(...middlewares);
```

Because middleware simply wraps `dispatch()` to return a function of the same signature, they can be used completely within userland. However, for the most part, you'll want to apply them globally to every action dispatch.

## Example of how to write middleware

Here's a middleware for adding naive promise support to Redux:

```js
function promiseMiddleware(next) {
  return action =>
    action && typeof action.then === 'function'
      ? action.then(next)
      : next(action);
}
```

## Use cases

Usually, they'll be used like schedulers. They can be used to implement promise support (a la Flummox), observable support, generator support, whatever. Or they can simply be used for side-effects like logging.

## How this affects the core API

This PR does not break the default behavior of the existing API. For instance, while `perform()` has been re-implemented as middleware internally, it is the default middleware if none is configured by the user.

In the future, Redux may provide some additional middlewares for things like optimistic updates, but they will be completely optional and not enabled by default.

## Why is middleware special? Why not simply tell users to provide a custom Dispatcher and call it a day?

[Custom dispatchers](https://github.com/gaearon/redux/releases/tag/v0.9.0) are the way to go for advanced functionality like time travel and transactions. But middleware *is* special because of a very important property: because middleware wraps the `dispatch()` method, it's inherently compatible with any dispatcher, regardless of implementation.

Still, middleware is totally optional, and each dispatcher implementation can choose whether or not to support them. (At the global level, that is — middleware can always be used from the calling site.)