### PR TITLE
Extract selectState and set initial state in constructor

### DIFF
--- a/src/components/Connector.js
+++ b/src/components/Connector.js
@@ -37,7 +37,8 @@ export default class Connector extends Component {
 
     this.handleChange = this.handleChange.bind(this);
     this.unsubscribe = context.redux.subscribe(this.handleChange);
-    this.handleChange();
+
+    this.state = this.selectState({ context, props });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -52,14 +53,12 @@ export default class Connector extends Component {
   }
 
   handleChange() {
-    const state = this.context.redux.getState();
-    const slice = this.props.select(state);
+    this.setState(this.selectState());
+  }
 
-    if (this.state) {
-      this.setState({ slice });
-    } else {
-      this.state = { slice };
-    }
+  selectState({ context, props } = this) {
+    const state = context.redux.getState();
+    return props.select(state);
   }
 
   render() {


### PR DESCRIPTION
Another attempt at https://github.com/gaearon/redux/pull/66.

This has the benefit of associating `this.props.select` with its use (`selectState`).