### PR TITLE
Make setState return the state that was set

### DIFF
--- a/src/Redux.js
+++ b/src/Redux.js
@@ -37,6 +37,7 @@ export default class Redux {
   setState(nextState) {
     this.state = nextState;
     this.listeners.forEach(listener => listener());
+    return nextState;
   }
 
   subscribe(listener) {

--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -2,12 +2,10 @@ import compose from './utils/composeMiddleware';
 
 export default function createDispatcher(store, middlewares = []) {
   return function dispatcher(initialState, setState) {
-    let state = store(initialState, {});
-    setState(state);
+    let state = setState(store(initialState, {}));
 
     function dispatch(action) {
-      state = store(state, action);
-      setState(state);
+      state = setState(store(state, action));
       return action;
     }
 

--- a/test/createDispatcher.spec.js
+++ b/test/createDispatcher.spec.js
@@ -10,11 +10,15 @@ const { ADD_TODO } = constants;
 describe('createDispatcher', () => {
 
   it('should handle sync and async dispatches', done => {
-    const spy = expect.createSpy(() => {});
+    const spy = expect.createSpy(
+      nextState => nextState
+    ).andCallThrough();
+
     const dispatcher = createDispatcher(
       composeStores({ todoStore }),
       // we need this middleware to handle async actions
-      getState => [thunkMiddleware(getState)]);
+      getState => [thunkMiddleware(getState)]
+    );
 
     expect(dispatcher).toBeA('function');
 


### PR DESCRIPTION
Related: #68, #62

I want to make this change to make custom dispatchers more composable.

The store is still managed by the “main” dispatcher, but now wrappers (such as a time travelling wrapper) are able to intercept the state that dispatcher is attempting to set, and, perhaps, put information of their own there too.

With this change, the `setState` call bubbles from the innermost dispatcher up to the Redux instance, and goes back with the state that was actually set.