### PR TITLE
Export default middlewares and use consistent naming

### DIFF
--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -1,4 +1,4 @@
-import compose from './utils/composeMiddleware';
+import composeMiddleware from './utils/composeMiddleware';
 
 export default function createDispatcher(store, middlewares = []) {
   return function dispatcher(initialState, setState) {
@@ -17,6 +17,6 @@ export default function createDispatcher(store, middlewares = []) {
       middlewares = middlewares(getState);
     }
 
-    return compose(...middlewares, dispatch);
+    return composeMiddleware(...middlewares, dispatch);
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ export createRedux from './createRedux';
 export createDispatcher from './createDispatcher';
 
 // Utilities
-export compose from './utils/composeMiddleware';
+export composeMiddleware from './utils/composeMiddleware';
 export composeStores from './utils/composeStores';
 export bindActionCreators from './utils/bindActionCreators';

--- a/src/utils/composeMiddleware.js
+++ b/src/utils/composeMiddleware.js
@@ -1,3 +1,3 @@
-export default function compose(...middlewares) {
+export default function composeMiddleware(...middlewares) {
   return middlewares.reduceRight((composed, m) => m(composed));
 }

--- a/test/composeMiddleware.spec.js
+++ b/test/composeMiddleware.spec.js
@@ -1,17 +1,17 @@
 import expect from 'expect';
-import { compose } from '../src';
+import { composeMiddleware } from '../src';
 
 describe('Utils', () => {
-  describe('compose', () => {
+  describe('composeMiddleware', () => {
     it('should return combined middleware that executes from left to right', () => {
       const a = next => action => next(action + 'a');
       const b = next => action => next(action + 'b');
       const c = next => action => next(action + 'c');
       const dispatch = action => action;
 
-      expect(compose(a, b, c, dispatch)('')).toBe('abc');
-      expect(compose(b, c, a, dispatch)('')).toBe('bca');
-      expect(compose(c, a, b, dispatch)('')).toBe('cab');
+      expect(composeMiddleware(a, b, c, dispatch)('')).toBe('abc');
+      expect(composeMiddleware(b, c, a, dispatch)('')).toBe('bca');
+      expect(composeMiddleware(c, a, b, dispatch)('')).toBe('cab');
     });
   });
 });


### PR DESCRIPTION
To be consistent with e.g.: `composeStores`.

Also exporting the default `thunk` middleware is useful if I need to create a dispatcher with other middlewares, for example:

```js
import { createDispatcher, composeStores, middlewares } = 'redux';
import loggerMiddleware from './middlewares/logger';
import * as stores from './stores';

const dispatcher = createDispatcher(
  composeStores(stores),
  getState => [middlewares.thunk(getState), loggerMiddleware(getState)]
);
```

Does it make sense?