### PR TITLE
Throws an error when `select` not returns an object

### DIFF
--- a/src/components/createConnector.js
+++ b/src/components/createConnector.js
@@ -1,5 +1,6 @@
 import identity from 'lodash/utility/identity';
 import shallowEqual from '../utils/shallowEqual';
+import isPlainObject from 'lodash/lang/isPlainObject';
 
 export default function createConnector(React) {
   const { Component, PropTypes } = React;
@@ -59,6 +60,11 @@ export default function createConnector(React) {
     selectState({ context, props } = this) {
       const state = context.redux.getState();
       const slice = props.select(state);
+
+      if (!isPlainObject(slice)) {
+        throw new Error('prop `select` should always return an object');
+      }
+
       return { slice };
     }
 

--- a/src/components/createConnector.js
+++ b/src/components/createConnector.js
@@ -1,6 +1,7 @@
 import identity from 'lodash/utility/identity';
 import shallowEqual from '../utils/shallowEqual';
 import isPlainObject from 'lodash/lang/isPlainObject';
+import invariant from 'invariant';
 
 export default function createConnector(React) {
   const { Component, PropTypes } = React;
@@ -61,9 +62,11 @@ export default function createConnector(React) {
       const state = context.redux.getState();
       const slice = props.select(state);
 
-      if (!isPlainObject(slice)) {
-        throw new Error('prop `select` should always return an object');
-      }
+      invariant(
+        isPlainObject(slice),
+        'The return value of `select` prop must be an object. Instead received %s.',
+        slice
+      );
 
       return { slice };
     }

--- a/test/components/Connector.spec.js
+++ b/test/components/Connector.spec.js
@@ -144,5 +144,21 @@ describe('React', () => {
       const div = TestUtils.findRenderedDOMComponentWithTag(tree, 'div');
       expect(div.props.dispatch).toBe(redux.dispatch);
     });
+
+    it('should throw an error if `state` returns anything but a plain object', () => {
+      const redux = createRedux(() => {});
+
+      expect(() => {
+        TestUtils.renderIntoDocument(
+          <Provider redux={redux}>
+            {() => (
+              <Connector state={() => 1}>
+                {() => <div />}
+              </Connector>
+            )}
+          </Provider>
+        );
+      }).toThrow(/select/);
+    });
   });
 });


### PR DESCRIPTION
On Connector, verify if `select` prop, which is a function, returns an
object, and if not, throws an error.

Issue #78