### PR TITLE
Fix stale state inside action creators on hot reload

### DIFF
--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -13,10 +13,10 @@ export default function createDispatcher(store, middlewares = []) {
       return state;
     }
 
-    if (typeof middlewares === 'function') {
-      middlewares = middlewares(getState);
-    }
+    const finalMiddlewares = typeof middlewares === 'function' ?
+      middlewares(getState) :
+      middlewares;
 
-    return composeMiddleware(...middlewares, dispatch);
+    return composeMiddleware(...finalMiddlewares, dispatch);
   };
 }

--- a/test/createRedux.spec.js
+++ b/test/createRedux.spec.js
@@ -53,4 +53,17 @@ describe('createRedux', () => {
     ]);
     expect(changeListenerSpy.calls.length).toBe(1);
   });
+
+  it('should use existing state when replacing the dispatcher', () => {
+    redux.dispatch(addTodo('Hello'));
+
+    let nextRedux = createRedux({ todoStore });
+    redux.replaceDispatcher(nextRedux.getDispatcher());
+
+    let action = (_, getState) => {
+      expect(getState().todoStore).toEqual(redux.getState().todoStore);
+    };
+
+    nextRedux.dispatch(action);
+  });
 });

--- a/test/createRedux.spec.js
+++ b/test/createRedux.spec.js
@@ -60,10 +60,13 @@ describe('createRedux', () => {
     let nextRedux = createRedux({ todoStore });
     redux.replaceDispatcher(nextRedux.getDispatcher());
 
+    let state;
     let action = (_, getState) => {
-      expect(getState().todoStore).toEqual(redux.getState().todoStore);
+      state = getState().todoStore;
     };
 
     nextRedux.dispatch(action);
+
+    expect(state).toEqual(redux.getState().todoStore);
   });
 });

--- a/test/createRedux.spec.js
+++ b/test/createRedux.spec.js
@@ -65,7 +65,7 @@ describe('createRedux', () => {
       state = getState().todoStore;
     };
 
-    nextRedux.dispatch(action);
+    redux.dispatch(action);
 
     expect(state).toEqual(redux.getState().todoStore);
   });


### PR DESCRIPTION
This fixes #90 and includes a failing (now fixed!) test from #91 (thanks @aaronjensen!)

The issue was due to the inner function overwriting the `middlewares` parameter of the outer function during its first invocation, so `getState` was injected only once.