### PR TITLE
remove rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "mocha-jsdom": "~0.4.0",
     "react": "^0.13.0",
     "react-hot-loader": "^1.2.7",
-    "rimraf": "^2.3.4",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2"
   },

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-`npm bin`/rimraf ./lib
+rm -rf ./lib


### PR DESCRIPTION
because we can just `rm -rf`