### PR TITLE
Use relative paths in entry files

### DIFF
--- a/src/react-entry.js
+++ b/src/react-entry.js
@@ -1,1 +1,1 @@
-export * from 'lib/react';
+export * from './lib/react';

--- a/src/react-native-entry.js
+++ b/src/react-native-entry.js
@@ -1,1 +1,1 @@
-export * from 'lib/react-native';
+export * from './lib/react-native';


### PR DESCRIPTION
The paths should be relative, else it will result in `module "lib/react" not found`.