### PR TITLE
remove .jshintrc and make license up to date

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,0 @@
-{
-  "node": true,
-  "browser": true,
-  "esnext": true,
-  "newcap": false
-}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Dan Abramov
+Copyright (c) 2015 Dan Abramov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
from #reflux channel 
>chico [3:12 AM] 
>what is `.jshintrc` for when you actually use `eslint`?
>gaearon [3:28 AM] 
>@chico: Probably leftover from some earlier project :simple_smile:

also update year in license