### PR TITLE
Connector#componentWillReceiveProps should use the new value of `select`

### DIFF
--- a/src/components/createConnector.js
+++ b/src/components/createConnector.js
@@ -40,13 +40,13 @@ export default function createConnector(React) {
       super(props, context);
 
       this.unsubscribe = context.redux.subscribe(::this.handleChange);
-      this.state = this.selectState({ context, props });
+      this.state = this.selectState(props, context);
     }
 
     componentWillReceiveProps(nextProps) {
       if (nextProps.select !== this.props.select) {
         // Force the state slice recalculation
-        this.handleChange();
+        this.handleChange(nextProps);
       }
     }
 
@@ -54,11 +54,12 @@ export default function createConnector(React) {
       this.unsubscribe();
     }
 
-    handleChange() {
-      this.setState(this.selectState());
+    handleChange(props = this.props) {
+      const nextState = this.selectState(props, this.context);
+      this.setState(nextState);
     }
 
-    selectState({ context, props } = this) {
+    selectState(props, context) {
       const state = context.redux.getState();
       const slice = props.select(state);
 

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import jsdom from 'mocha-jsdom';
+import jsdomReact from './jsdomReact';
 import React, { PropTypes, Component } from 'react/addons';
 import { createRedux } from '../../src';
 import { Provider } from '../../src/react';
@@ -8,7 +8,7 @@ const { TestUtils } = React.addons;
 
 describe('React', () => {
   describe('Provider', () => {
-    jsdom();
+    jsdomReact();
 
     class Child extends Component {
       static contextTypes = {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import jsdom from 'mocha-jsdom';
+import jsdomReact from './jsdomReact';
 import React, { PropTypes, Component } from 'react/addons';
 import { createRedux } from '../../src';
 import { connect, Connector } from '../../src/react';
@@ -8,7 +8,7 @@ const { TestUtils } = React.addons;
 
 describe('React', () => {
   describe('provide', () => {
-    jsdom();
+    jsdomReact();
 
     // Mock minimal Provider interface
     class Provider extends Component {

--- a/test/components/jsdomReact.js
+++ b/test/components/jsdomReact.js
@@ -1,0 +1,7 @@
+import ExecutionEnvironment from 'react/lib/ExecutionEnvironment';
+import jsdom from 'mocha-jsdom';
+
+export default function jsdomReact() {
+  jsdom();
+  ExecutionEnvironment.canUseDOM = true;
+}

--- a/test/components/provide.spec.js
+++ b/test/components/provide.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import jsdom from 'mocha-jsdom';
+import jsdomReact from './jsdomReact';
 import React, { PropTypes, Component } from 'react/addons';
 import { createRedux } from '../../src';
 import { provide, Provider } from '../../src/react';
@@ -8,7 +8,7 @@ const { TestUtils } = React.addons;
 
 describe('React', () => {
   describe('provide', () => {
-    jsdom();
+    jsdomReact();
 
     class Child extends Component {
       static contextTypes = {


### PR DESCRIPTION
This fixes a bug that causes the state passed by `Connector` to stay stale when a new `select` function is passed. This PR includes a failing test and a fix that makes it pass.