### PR TITLE
Expose DecoratedComponent as static property.

### DIFF
--- a/src/components/createConnectDecorator.js
+++ b/src/components/createConnectDecorator.js
@@ -7,6 +7,7 @@ export default function createConnectDecorator(React, Connector) {
   return function connect(select) {
     return DecoratedComponent => class ConnectorDecorator extends Component {
       static displayName = `Connector(${getDisplayName(DecoratedComponent)})`;
+      static DecoratedComponent = DecoratedComponent;
 
       shouldComponentUpdate(nextProps) {
         return !shallowEqualScalar(this.props, nextProps);

--- a/src/components/createProvideDecorator.js
+++ b/src/components/createProvideDecorator.js
@@ -6,6 +6,7 @@ export default function createProvideDecorator(React, Provider) {
   return function provide(redux) {
     return DecoratedComponent => class ProviderDecorator extends Component {
       static displayName = `Provider(${getDisplayName(DecoratedComponent)})`;
+      static DecoratedComponent = DecoratedComponent;
 
       render() {
         return (

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -57,5 +57,18 @@ describe('React', () => {
 
       expect(Container.displayName).toBe('Connector(Container)');
     });
+
+    it('sets DecoratedComponent to wrapped component', () => {
+      class Container extends Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      let decorator = connect(state => state);
+      let ConnectorDecorator = decorator(Container);
+
+      expect(ConnectorDecorator.DecoratedComponent).toBe(Container);
+    });
   });
 });

--- a/test/components/provide.spec.js
+++ b/test/components/provide.spec.js
@@ -48,5 +48,18 @@ describe('React', () => {
 
       expect(Container.displayName).toBe('Provider(Container)');
     });
+
+    it('sets DecoratedComponent to wrapped component', () => {
+      class Container extends Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      let decorator = provide(state => state);
+      let ProviderDecorator = decorator(Container);
+
+      expect(ProviderDecorator.DecoratedComponent).toBe(Container);
+    });
   });
 });


### PR DESCRIPTION
This PR exposes the decorated component as a static property when using `@connect(...)`. This is great for removing the dependency on a redux instance in tests.

Before:
```
@connect(state => state)
class DecorateMe {
}

React.TestUtils.renderIntoDocument((
  <Provider redux={redux}>
    {() => <DecorateMe />}
  </Provider>
));
```

After:
```
@connect(state => state)
class DecorateMe {
}

React.TestUtils.renderIntoDocument(<DecorateMe.DecoratedComponent {...props} />);
```