### PR TITLE
Gracefully handle nested dispatches

### DIFF
--- a/test/createRedux.spec.js
+++ b/test/createRedux.spec.js
@@ -69,4 +69,29 @@ describe('createRedux', () => {
 
     expect(state).toEqual(redux.getState().todoStore);
   });
+
+  it('should handle nested dispatches gracefully', () => {
+    function foo(state = 0, action) {
+      return action.type === 'foo' ? 1 : state;
+    }
+
+    function bar(state = 0, action) {
+      return action.type === 'bar' ? 2 : state;
+    }
+
+    const redux = createRedux({ foo, bar });
+
+    redux.subscribe(() => {
+      // What the Connector ends up doing.
+      const state = redux.getState();
+      if (state.foo !== 0) {
+        redux.dispatch({type: 'bar'});
+      }
+    });
+
+    redux.dispatch({type: 'foo'});
+
+    // Either this or throw an error when nesting dispatchers
+    expect(redux.getState()).toEqual({foo: 1, bar: 2});
+  });
 });


### PR DESCRIPTION
Currently, when we happen to have nested dispatches, the last action's returned state prevails, even if they belong to different stores. The nested dispatch still sees the state as if the outer dispatch wasn't executed yet, so it ends up overwriting whatever that outer dispatch did.

Perhaps it's more clear with the failing test that I'm providing here. I'd expect there to either have both dispatches applied, or the dispatcher to throw an exception or a warning, as the original Facebook's Flux dispatcher.

The use case for running into nested dispatches is the classic "need data in componentWillMount", which triggers an action creator that dispatches an action immediately, and is executed as a consequence of a previous dispatch.

I'm leaving this unsolved until we decide the way to go, after that I can fix the test with the expected behavior