### PR TITLE
Remove unnecessary browserify config in package.json and envify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,13 +54,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.5.8",
-    "envify": "^3.4.0",
     "invariant": "^2.0.0",
     "lodash": "^3.9.3"
-  },
-  "browserify": {
-    "transform": [
-      "envify"
-    ]
   }
 }


### PR DESCRIPTION
This PR removes the `browserify` config in `package.json` and the dependency to `envify` (#88) which doesn't seem to be used.