### PR TITLE
Give the initial action a Symbol type

### DIFF
--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -1,8 +1,10 @@
 import composeMiddleware from './utils/composeMiddleware';
 
+const INIT = Symbol('INIT');
+
 export default function createDispatcher(store, middlewares = []) {
   return function dispatcher(initialState, setState) {
-    let state = setState(store(initialState, {}));
+    let state = setState(store(initialState, { type: INIT }));
 
     function dispatch(action) {
       state = setState(store(state, action));


### PR DESCRIPTION
I [intend to](https://github.com/gaearon/redux/issues/113#issue-88862407) use Symbol types for “internal” (or devtools-related) actions that the app should not handle.

As the first change, I propose to give a Symbol type to the initial action used to bootstrap the Store. (Currently it has no type at all.)

I can't imagine a situation in which a Store would want to *know* whether it's the initial action or not. So I don't think it's needed to expose this Symbol.