### PR TITLE
Stateless dispatcher

### DIFF
--- a/src/Redux.js
+++ b/src/Redux.js
@@ -9,7 +9,7 @@ export default class Redux {
       // A shortcut notation to use the default dispatcher
       dispatcher = createDispatcher(
         composeStores(dispatcher),
-        ({ getState }) => [thunkMiddleware(getState)]
+        getState => [thunkMiddleware(getState)]
       );
     }
 

--- a/src/Redux.js
+++ b/src/Redux.js
@@ -1,9 +1,10 @@
 import createDispatcher from './createDispatcher';
 import composeStores from './utils/composeStores';
 import thunkMiddleware from './middleware/thunk';
+import identity from 'lodash/utility/identity';
 
 export default class Redux {
-  constructor(dispatcher, initialState) {
+  constructor(dispatcher, initialState, prepareState = identity) {
     if (typeof dispatcher === 'object') {
       // A shortcut notation to use the default dispatcher
       dispatcher = createDispatcher(
@@ -13,6 +14,7 @@ export default class Redux {
     }
 
     this.state = initialState;
+    this.prepareState = prepareState;
     this.listeners = [];
     this.replaceDispatcher(dispatcher);
   }
@@ -24,7 +26,7 @@ export default class Redux {
   replaceDispatcher(nextDispatcher) {
     this.dispatcher = nextDispatcher;
     this.dispatchFn = nextDispatcher({
-      getState: ::this.getState,
+      getState: ::this.getRawState,
       setState: ::this.setState
     });
     this.dispatch({});
@@ -34,8 +36,12 @@ export default class Redux {
     return this.dispatchFn(action);
   }
 
-  getState() {
+  getRawState() {
     return this.state;
+  }
+
+  getState() {
+    return this.prepareState(this.state);
   }
 
   setState(nextState) {

--- a/src/Redux.js
+++ b/src/Redux.js
@@ -8,7 +8,7 @@ export default class Redux {
       // A shortcut notation to use the default dispatcher
       dispatcher = createDispatcher(
         composeStores(dispatcher),
-        getState => [thunkMiddleware(getState)]
+        ({ getState }) => [thunkMiddleware(getState)]
       );
     }
 
@@ -23,7 +23,11 @@ export default class Redux {
 
   replaceDispatcher(nextDispatcher) {
     this.dispatcher = nextDispatcher;
-    this.dispatchFn = nextDispatcher(this.state, ::this.setState);
+    this.dispatchFn = nextDispatcher({
+      getState: ::this.getState,
+      setState: ::this.setState
+    });
+    this.dispatch({});
   }
 
   dispatch(action) {

--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -1,20 +1,14 @@
 import composeMiddleware from './utils/composeMiddleware';
 
 export default function createDispatcher(store, middlewares = []) {
-  return function dispatcher(initialState, setState) {
-    let state = setState(store(initialState, {}));
-
+  return function dispatcher({ getState, setState }) {
     function dispatch(action) {
-      state = setState(store(state, action));
+      setState(store(getState(), action));
       return action;
     }
 
-    function getState() {
-      return state;
-    }
-
     const finalMiddlewares = typeof middlewares === 'function' ?
-      middlewares(getState) :
+      middlewares({ getState, setState, dispatch }) :
       middlewares;
 
     return composeMiddleware(...finalMiddlewares, dispatch);

--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -8,7 +8,7 @@ export default function createDispatcher(store, middlewares = []) {
     }
 
     const finalMiddlewares = typeof middlewares === 'function' ?
-      middlewares({ getState, setState, dispatch }) :
+      middlewares(getState, setState, dispatch) :
       middlewares;
 
     return composeMiddleware(...finalMiddlewares, dispatch);

--- a/test/components/Connector.spec.js
+++ b/test/components/Connector.spec.js
@@ -188,13 +188,13 @@ describe('React', () => {
     });
 
     it('should throw an error if `state` returns anything but a plain object', () => {
-      const redux = createRedux(() => {});
+      const redux = createRedux({ test: () => 'test' });
 
       expect(() => {
         TestUtils.renderIntoDocument(
           <Provider redux={redux}>
             {() => (
-              <Connector state={() => 1}>
+              <Connector select={() => 1}>
                 {() => <div />}
               </Connector>
             )}

--- a/test/createRedux.spec.js
+++ b/test/createRedux.spec.js
@@ -69,4 +69,29 @@ describe('createRedux', () => {
 
     expect(state).toEqual(redux.getState().todoStore);
   });
+
+  it('should handle nested dispatches gracefully', () => {
+    function foo(state = 0, action) {
+      return action.type === 'foo' ? 1 : state;
+    }
+
+    function bar(state = 0, action) {
+      return action.type === 'bar' ? 2 : state;
+    }
+
+    redux = createRedux({ foo, bar });
+
+    redux.subscribe(() => {
+      // What the Connector ends up doing.
+      const state = redux.getState();
+      if (state.bar === 0) {
+        redux.dispatch({type: 'bar'});
+      }
+    });
+
+    redux.dispatch({type: 'foo'});
+
+    // Either this or throw an error when nesting dispatchers
+    expect(redux.getState()).toEqual({foo: 1, bar: 2});
+  });
 });


### PR DESCRIPTION
This PR mainly does two things:

1) Makes the dispatcher stateless. Side-effect-y, so not quite "pure", but with no local state. Instead, it is passed `setState()` by the dispatcher.
2) `createRedux()` accepts `prepareState()` as the third parameter*, which is used to prepare the atom before being sent to subscribers. Akin to a global `selectState()`, but with a different name to avoid confusion (e.g. `prepareState()` does not have to return a plain object).

*I don't like this as a final API, but we should discuss this more before introducing a breaking change to `createRedux()`.

These two changes allow custom dispatchers to store "meta" state on the state atom without exposing it to consumers. https://github.com/gaearon/redux/issues/113

It also changes the signature of the dispatcher (by which I mean the higher-order function that creates `dispatchFn()` — we really need to work on / document some of this terminology) from `dispatcher(initialState, setState)` to `dispatcher({ getState, setState })`. It does not include `dispatch` as suggested [here](https://github.com/gaearon/redux/issues/113#issuecomment-112602119), since that can be implemented inside the dispatcher instead.

~~Speaking of which, the `createDispatcher()` API has been changed slightly to~~ I'll submit a separate PR for this, since it's not really related.

```js
createDispatcher({
  stores,
  middleware: ({ setState, getState, dispatch }) => middlewares
});
```

Thoughts? I will update with better `createRedux()` API once we come to a consensus.