### PR TITLE
Give the initial action a special type

### DIFF
--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -1,8 +1,12 @@
 import composeMiddleware from './utils/composeMiddleware';
 
+const INIT_ACTION = {
+  type: '@@INIT'
+};
+
 export default function createDispatcher(store, middlewares = []) {
   return function dispatcher(initialState, setState) {
-    let state = setState(store(initialState, {}));
+    let state = setState(store(initialState, INIT_ACTION));
 
     function dispatch(action) {
       state = setState(store(state, action));


### PR DESCRIPTION
Supersedes #114.

I want to establish a convention for “built-in” and “devtools” action types (more will come in #113) so that the tools are able to distinguish them, and so the user doesn't feel compelled to handle them and can clearly see that they are not from their app.

Thanks to @ooflorent for the `@@` naming tip.