### PR TITLE
Replace lodash's mapValues

### DIFF
--- a/src/utils/bindActionCreators.js
+++ b/src/utils/bindActionCreators.js
@@ -1,4 +1,4 @@
-import mapValues from 'lodash/object/mapValues';
+import mapValues from '../utils/mapValues';
 
 export default function bindActionCreators(actionCreators, dispatch) {
   return mapValues(actionCreators, actionCreator =>

--- a/src/utils/composeStores.js
+++ b/src/utils/composeStores.js
@@ -1,4 +1,4 @@
-import mapValues from 'lodash/object/mapValues';
+import mapValues from '../utils/mapValues';
 import pick from 'lodash/object/pick';
 
 export default function composeStores(stores) {

--- a/src/utils/mapValues.js
+++ b/src/utils/mapValues.js
@@ -1,0 +1,6 @@
+export default function mapValues(obj, fn) {
+  return Object.keys(obj).reduce((result, key) => {
+    result[key] = fn(obj[key], key);
+    return result;
+  }, {});
+}

--- a/test/utils/mapValues.spec.js
+++ b/test/utils/mapValues.spec.js
@@ -1,0 +1,12 @@
+import expect from 'expect';
+import mapValues from '../../src/utils/mapValues';
+
+describe('Utils', () => {
+  describe('mapValues', () => {
+    it('should return object with mapped values', () => {
+      const test = { 'a': 1, 'b': 2 };
+      expect(mapValues(test, val => val * 3)).toEqual({ 'a': 3, 'b': 6 });
+    });
+  });
+});
+

--- a/test/utils/mapValues.spec.js
+++ b/test/utils/mapValues.spec.js
@@ -4,8 +4,8 @@ import mapValues from '../../src/utils/mapValues';
 describe('Utils', () => {
   describe('mapValues', () => {
     it('should return object with mapped values', () => {
-      const test = { 'a': 1, 'b': 2 };
-      expect(mapValues(test, val => val * 3)).toEqual({ 'a': 3, 'b': 6 });
+      const test = { 'a': 'c', 'b': 'd' };
+      expect(mapValues(test, (val, key) => val + key)).toEqual({ 'a': 'ca', 'b': 'db' });
     });
   });
 });


### PR DESCRIPTION
From #112's discussion, this replaces lodash's `mapValues` to reduce the number of lodash dependencies.