### PR TITLE
Replace lodash utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
   "dependencies": {
     "babel-runtime": "^5.5.8",
     "envify": "^3.4.0",
-    "invariant": "^2.0.0",
-    "lodash": "^3.9.3"
+    "invariant": "^2.0.0"
   },
   "browserify": {
     "transform": [

--- a/src/components/createConnector.js
+++ b/src/components/createConnector.js
@@ -1,6 +1,6 @@
-import identity from 'lodash/utility/identity';
+import identity from '../utils/identity';
 import shallowEqual from '../utils/shallowEqual';
-import isPlainObject from 'lodash/lang/isPlainObject';
+import isPlainObject from '../utils/isPlainObject';
 import invariant from 'invariant';
 
 export default function createConnector(React) {

--- a/src/utils/composeStores.js
+++ b/src/utils/composeStores.js
@@ -1,5 +1,5 @@
 import mapValues from '../utils/mapValues';
-import pick from 'lodash/object/pick';
+import pick from '../utils/pick';
 
 export default function composeStores(stores) {
   stores = pick(stores, (val) => typeof val === 'function');

--- a/src/utils/identity.js
+++ b/src/utils/identity.js
@@ -1,0 +1,3 @@
+export default function identity(value) {
+  return value;
+}

--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -1,0 +1,3 @@
+export default function isPlainObject(obj) {
+  return typeof obj == 'object' && Object.getPrototypeOf(obj) === Object.prototype;
+}

--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -1,3 +1,3 @@
 export default function isPlainObject(obj) {
-  return typeof obj == 'object' && Object.getPrototypeOf(obj) === Object.prototype;
+  return typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype;
 }

--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -1,3 +1,3 @@
 export default function isPlainObject(obj) {
-  return typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype;
+  return obj ? typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype : false;
 }

--- a/src/utils/pick.js
+++ b/src/utils/pick.js
@@ -1,0 +1,8 @@
+export default function pick(obj, fn) {
+  return Object.keys(obj).reduce((result, key) => {
+    if (fn(obj[key])) {
+      result[key] = obj[key];
+    }
+    return result;
+  }, {});
+}

--- a/test/utils/identity.spec.js
+++ b/test/utils/identity.spec.js
@@ -5,7 +5,7 @@ describe('Utils', () => {
   describe('identity', () => {
     it('should return first argument passed to it', () => {
       var test = { 'a': 1 };
-      expect(identity(test, 'test')).toEqual(test);
+      expect(identity(test, 'test')).toBe(test);
     });
   });
 });

--- a/test/utils/identity.spec.js
+++ b/test/utils/identity.spec.js
@@ -1,0 +1,11 @@
+import expect from 'expect';
+import identity from '../../src/utils/identity';
+
+describe('Utils', () => {
+  describe('identity', () => {
+    it('should return first argument passed to it', () => {
+      var test = { 'a': 1 };
+      expect(identity(test, 'test')).toEqual(test);
+    });
+  });
+});

--- a/test/utils/isPlainObject.spec.js
+++ b/test/utils/isPlainObject.spec.js
@@ -1,0 +1,17 @@
+import expect from 'expect';
+import isPlainObject from '../../src/utils/isPlainObject';
+
+describe('Utils', () => {
+  describe('isPlainObject', () => {
+    it('should return true only if plain object', () => {
+      function Test() {
+        this.prop = 1;
+      }
+
+      expect(isPlainObject(new Test())).toBe(false);
+      expect(isPlainObject(new Date())).toBe(false);
+      expect(isPlainObject([1, 2, 3])).toBe(false);
+      expect(isPlainObject({ 'x': 1, 'y': 2 })).toBe(true);
+    });
+  });
+});

--- a/test/utils/isPlainObject.spec.js
+++ b/test/utils/isPlainObject.spec.js
@@ -11,6 +11,8 @@ describe('Utils', () => {
       expect(isPlainObject(new Test())).toBe(false);
       expect(isPlainObject(new Date())).toBe(false);
       expect(isPlainObject([1, 2, 3])).toBe(false);
+      expect(isPlainObject(null)).toBe(false);
+      expect(isPlainObject()).toBe(false);
       expect(isPlainObject({ 'x': 1, 'y': 2 })).toBe(true);
     });
   });

--- a/test/utils/pick.spec.js
+++ b/test/utils/pick.spec.js
@@ -1,0 +1,11 @@
+import expect from 'expect';
+import pick from '../../src/utils/pick';
+
+describe('Utils', () => {
+  describe('pick', () => {
+    it('should return object with picked values', () => {
+      const test = { 'name': 'lily', 'age': 20 };
+      expect(pick(test, x => typeof x === 'string')).toEqual({ 'name': 'lily' });
+    });
+  });
+});


### PR DESCRIPTION
From #112 -- Removing lodash utils decreases the build size significantly as described by @dariocravero so this PR replaces the remaining three lodash modules with basic utils. 