### PR TITLE
WIP: Add warnMutations middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,11 @@
     "rimraf": "^2.3.4",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2",
-    "immutable": "~3.7.4"
+    "immutable": "^3.7.4"
   },
   "dependencies": {
-    "invariant": "^2.0.0"
+    "invariant": "^2.0.0",
+    "lodash.clonedeep": "^3.0.1"
   },
   "npmName": "redux",
   "npmFileMap": [

--- a/package.json
+++ b/package.json
@@ -51,16 +51,19 @@
     "react-hot-loader": "^1.2.7",
     "rimraf": "^2.3.4",
     "webpack": "^1.9.6",
-    "webpack-dev-server": "^1.8.2"
+    "webpack-dev-server": "^1.8.2",
+    "immutable": "~3.7.4"
   },
   "dependencies": {
     "invariant": "^2.0.0"
   },
   "npmName": "redux",
-  "npmFileMap": [{
-    "basePath": "/dist/",
-    "files": [
-      "*.js"
-    ]
-  }]
+  "npmFileMap": [
+    {
+      "basePath": "/dist/",
+      "files": [
+        "*.js"
+      ]
+    }
+  ]
 }

--- a/src/middleware/warnMutations.js
+++ b/src/middleware/warnMutations.js
@@ -1,0 +1,54 @@
+import isEqual from 'lodash/lang/isEqual';
+import any from 'lodash/collection/any';
+import cloneDeep from 'lodash/lang/cloneDeep';
+
+function copyState(state) {
+  return cloneDeep(state);
+}
+
+function wasMutated(prevStateRef, prevState, stateRef, state) {
+  if (prevStateRef === stateRef && !isEqual(prevState, state)) {
+    return true;
+  }
+
+  if (typeof prevStateRef !== 'object') {
+    return false;
+  }
+
+  return any(prevStateRef, (val, key) =>
+    wasMutated(val, prevState[key], stateRef[key], state[key]));
+}
+
+export default function warnMutationsMiddleware(getState) {
+  let lastStateRef = getState();
+  let lastState = copyState(lastStateRef);
+
+  return (next) => (action) => {
+    const stateRef = getState();
+    const state = copyState(stateRef);
+
+    if (wasMutated(lastStateRef, lastState, stateRef, state)) {
+      console.warn([
+        'A state mutation was detected between dispatches.' +
+        ' This may cause incorrect behavior.',
+        '(https://github.com/gaearon/redux#my-views-arent-updating)'
+      ].join(''));
+    };
+
+    action = next(action);
+
+    lastStateRef = getState();
+    lastState = copyState(lastStateRef);
+
+    if (wasMutated(stateRef, state, lastStateRef, lastState)) {
+      console.warn(
+        'A state mutation was detected inside a dispatch.',
+        ` Take a look at the store(s) handling the action`,
+        action,
+        '(https://github.com/gaearon/redux#my-views-arent-updating)'
+      );
+    }
+
+    return action;
+  };
+}

--- a/src/middleware/warnMutations.js
+++ b/src/middleware/warnMutations.js
@@ -33,7 +33,7 @@ export default function warnMutationsMiddleware(getState) {
         ' This may cause incorrect behavior.',
         '(https://github.com/gaearon/redux#my-views-arent-updating)'
       ].join(''));
-    };
+    }
 
     action = next(action);
 

--- a/src/middleware/warnMutations.js
+++ b/src/middleware/warnMutations.js
@@ -1,9 +1,11 @@
 import invariant from 'invariant';
 import isPlainObject from '../utils/isPlainObject';
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
 function any(collection, predicate) {
   for (let key in collection) {
-    if (collection.hasOwnProperty(key)) {
+    if (hasOwn.call(collection, key)) {
       if (predicate(collection[key], key)) {
         return true;
       }
@@ -32,7 +34,7 @@ function copyState(state, isImmutable) {
   const keysAndValues = [];
 
   for (let key in state) {
-    if (state.hasOwnProperty(key)) {
+    if (hasOwn.call(state, key)) {
       keysAndValues.push([key, copyState(state[key], isImmutable)]);
     }
   }

--- a/test/middleware/warnMutations.spec.js
+++ b/test/middleware/warnMutations.spec.js
@@ -1,0 +1,79 @@
+import expect from 'expect';
+import warnMutationsMiddleware from '../../src/middleware/warnMutations';
+
+describe('middleware', () => {
+  describe('warnMutationsMiddleware', () => {
+    let warnSpy, state;
+    const getState = () => state;
+
+    beforeEach(() => {
+      const original = console.warn;
+      warnSpy = expect.spyOn(console, 'warn');
+      warnSpy.original = original;
+    });
+
+    afterEach(() => {
+      console.warn = warnSpy.original;
+    });
+
+
+    it('should send the action through the middleware chain', () => {
+      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+      const next = action => action;
+      const dispatch = warnMutationsMiddleware(getState)(next);
+
+      expect(dispatch({type: 'SOME_ACTION'})).toEqual({type: 'SOME_ACTION'});
+    });
+
+    it('should warn if there is a state mutation inside the dispatch', () => {
+      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+
+      const next = action => {
+        state.foo.baz = 'changed!';
+        return action;
+      };
+
+      const dispatch = warnMutationsMiddleware(getState)(next);
+
+      dispatch({type: 'SOME_ACTION'});
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('should not warn if dispatch returns a new state object', () => {
+      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+
+      const next = action => {
+        state = {...state, foo: {...state.foo, baz: 'changed!'}};
+        return action;
+      };
+
+      const dispatch = warnMutationsMiddleware(getState)(next);
+
+      dispatch({type: 'SOME_ACTION'});
+      expect(warnSpy.calls.length).toBe(0);
+    });
+
+    it('should warn if a state mutation happened between dispatches', () => {
+      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+      const next = action => action;
+
+      const dispatch = warnMutationsMiddleware(getState)(next);
+
+      dispatch({type: 'SOME_ACTION'});
+      state.foo.baz = 'changed!';
+      dispatch({type: 'SOME_OTHER_ACTION'});
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('should not warn if there weren\'t any state mutations between dispatches', () => {
+      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+      const next = action => action;
+
+      const dispatch = warnMutationsMiddleware(getState)(next);
+
+      dispatch({type: 'SOME_ACTION'});
+      dispatch({type: 'SOME_OTHER_ACTION'});
+      expect(warnSpy.calls.length).toBe(0);
+    });
+  });
+});

--- a/test/middleware/warnMutations.spec.js
+++ b/test/middleware/warnMutations.spec.js
@@ -1,4 +1,5 @@
 import expect from 'expect';
+import Immutable from 'immutable';
 import warnMutationsMiddleware from '../../src/middleware/warnMutations';
 
 describe('middleware', () => {
@@ -6,68 +7,118 @@ describe('middleware', () => {
     let state;
     const getState = () => state;
 
+    function middleware(next) {
+      return warnMutationsMiddleware(getState)(next);
+    }
+
+    function testCasesForMutation(mutation) {
+      it('should throw if happening inside the dispatch', () => {
+        const next = action => {
+          state = mutation(state);
+          return action;
+        };
+
+        const dispatch = middleware(next);
+
+        expect(() => {
+          dispatch({type: 'SOME_ACTION'});
+        }).toThrow();
+      });
+
+      it('should throw if happening between dispatches', () => {
+        const next = action => action;
+
+        const dispatch = middleware(next);
+
+        dispatch({type: 'SOME_ACTION'});
+        state = mutation(state);
+        expect(() => {
+          dispatch({type: 'SOME_OTHER_ACTION'});
+        }).toThrow();
+      });
+    }
+
+    function testCasesForNonMutation(nonMutation) {
+
+      it('should not throw if happening inside the dispatch', () => {
+        const next = action => {
+          state = nonMutation(state);
+          return action;
+        };
+
+        const dispatch = middleware(next);
+
+        expect(() => {
+          dispatch({type: 'SOME_ACTION'});
+        }).toNotThrow();
+      });
+
+      it('should not throw if happening between dispatches', () => {
+        const next = action => action;
+
+        const dispatch = middleware(next);
+
+        dispatch({type: 'SOME_ACTION'});
+        state = nonMutation(state);
+        expect(() => {
+          dispatch({type: 'SOME_OTHER_ACTION'});
+        }).toNotThrow();
+      });
+    }
+
+    beforeEach(() => {
+      state = {foo: {bar: [2, 3, 4], baz: 'baz', qux: Immutable.fromJS({a: 1, b: 2})}};
+    });
+
     it('should send the action through the middleware chain', () => {
-      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
       const next = action => action;
-      const dispatch = warnMutationsMiddleware(getState)(next);
+      const dispatch = middleware(next);
 
       expect(dispatch({type: 'SOME_ACTION'})).toEqual({type: 'SOME_ACTION'});
     });
 
-    it('should throw if there is a state mutation inside the dispatch', () => {
-      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+    const mutations = {
+      'mutating nested array': (s) => {
+        s.foo.bar.push(5);
+        return s;
+      },
+      'mutating nested array and setting new root object': (s) => {
+        s.foo.bar.push(5);
+        return {...s};
+      },
+      'changing nested string': (s) => {
+        s.foo.baz = 'changed!';
+        return s;
+      },
+      'setting a nested immutable object': (s) => {
+        s.foo.qux = s.foo.qux.set('a', 3);
+        return s;
+      }
+    };
 
-      const next = action => {
-        state.foo.baz = 'changed!';
-        return action;
-      };
-
-      const dispatch = warnMutationsMiddleware(getState)(next);
-
-      expect(() => {
-        dispatch({type: 'SOME_ACTION'});
-      }).toThrow();
+    Object.keys(mutations).forEach((mutationDesc) => {
+      describe(`mutating state by ${mutationDesc}`, () => {
+        testCasesForMutation(mutations[mutationDesc]);
+      });
     });
 
-    it('should not throw if dispatch returns a new state object', () => {
-      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+    const nonMutations = {
+      'returning same state': (s) => s,
+      'returning a new state object with nested new string': (s) => {
+        return {...s, foo: {...s.foo, baz: 'changed!'}};
+      },
+      'returning a new state object with nested new array': (s) => {
+        return {...s, foo: {...s.foo, bar: [...s.foo.bar, 5]}};
+      },
+      'returning a new state object with nested new immutable state': (s) => {
+        return {...s, foo: {...s.foo, qux: s.foo.qux.set('a', 3)}};
+      }
+    };
 
-      const next = action => {
-        state = {...state, foo: {...state.foo, baz: 'changed!'}};
-        return action;
-      };
-
-      const dispatch = warnMutationsMiddleware(getState)(next);
-
-      expect(() => {
-        dispatch({type: 'SOME_ACTION'});
-      }).toNotThrow();
-    });
-
-    it('should throw if a state mutation happened between dispatches', () => {
-      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
-      const next = action => action;
-
-      const dispatch = warnMutationsMiddleware(getState)(next);
-
-      dispatch({type: 'SOME_ACTION'});
-      state.foo.baz = 'changed!';
-
-      expect(() => {
-        dispatch({type: 'SOME_OTHER_ACTION'});
-      }).toThrow();
-    });
-
-    it('should not throw if there weren\'t any state mutations between dispatches', () => {
-      state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
-      const next = action => action;
-
-      const dispatch = warnMutationsMiddleware(getState)(next);
-
-      dispatch({type: 'SOME_ACTION'});
-      expect(() => {
-        dispatch({type: 'SOME_OTHER_ACTION'});
-      }).toNotThrow();
+    Object.keys(nonMutations).forEach((nonMutationDesc) => {
+      describe(`not mutating state by ${nonMutationDesc}`, () => {
+        testCasesForNonMutation(nonMutations[nonMutationDesc]);
+      });
     });
   });
 });


### PR DESCRIPTION
Aims to fix https://github.com/gaearon/redux/issues/135

I've implemented the mutation warnings as a middleware, which expects to receive plain actions (should be the last in the chain or at least should be after the ones that transform the actions such as the `thunkMiddleware`).

Still need to provide support for stuff like ImmutableJS but should be straight forward. Also, I'm leaving it like this so that we can discuss implementation.

We can also discuss what's the best way to handle adding this middleware by default on dev, but not in prod (and avoid including the dependencies as well).