### PR TITLE
Revisit dependencies and add browser ready builds

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "stage": 0,
-  "optional": ["runtime"]
+  "loose": "all"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
 .DS_Store
+dist
 lib
 coverage
 react.js

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,16 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased][unreleased]
+### Added
+- Dist build script (borrowed from flummox) to create distribution ready builds of redux
+  that can be used in a browser directly. `dist/` is ignored by git.
+- Configuration for `cdnjs` autoimport from npm.
+
+### Changed
+- Clean up package.json by removing the unused browserify section;
+- Remove envify and babel-runtime as they aren't being used;
+- A change log :)
+
+[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.11.1...HEAD

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Atomic Flux with hot reloading",
   "main": "lib/index.js",
   "scripts": {
+    "browser": "scripts/browser",
     "build": "scripts/build",
     "clean": "scripts/clean",
     "lint": "scripts/lint",
@@ -53,13 +54,13 @@
     "webpack-dev-server": "^1.8.2"
   },
   "dependencies": {
-    "babel-runtime": "^5.5.8",
-    "envify": "^3.4.0",
     "invariant": "^2.0.0"
   },
-  "browserify": {
-    "transform": [
-      "envify"
+  "npmName": "redux",
+  "npmFileMap": [{
+    "basePath": "/dist/",
+    "files": [
+      "*.js"
     ]
-  }
+  }]
 }

--- a/scripts/browser
+++ b/scripts/browser
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+WEBPACK_CMD=node_modules/.bin/webpack
+
+mkdir -p dist
+
+$WEBPACK_CMD src/index.js dist/redux.js
+NODE_ENV=production $WEBPACK_CMD src/index.js dist/redux.min.js
+
+$WEBPACK_CMD src/react.js dist/redux-react.js
+NODE_ENV=production $WEBPACK_CMD src/react.js dist/redux-react.min.js
+
+$WEBPACK_CMD src/react-native.js dist/redux-react-native.js
+NODE_ENV=production $WEBPACK_CMD src/react-native.js dist/redux-react-native.min.js

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -2,4 +2,5 @@
 
 sh scripts/lint
 sh scripts/clean
+sh scripts/browser
 sh scripts/build

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var webpack = require('webpack');
+
+var plugins = [
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+  }),
+  new webpack.optimize.OccurenceOrderPlugin()
+];
+
+if (process.env.NODE_ENV === 'production') {
+  plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        screw_ie8: true,
+        warnings: false
+      }
+    })
+  );
+}
+
+module.exports = {
+  externals: {
+    'react': 'React',
+    'react-native': 'React'
+  },
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    ]
+  },
+  output: {
+    library: 'Redux',
+    libraryTarget: 'var'
+  },
+  plugins: plugins,
+  resolve: {
+    extensions: ['', '.js']
+  }
+};


### PR DESCRIPTION
Added:
- Dist build script (borrowed from flummox) to create distribution ready builds of redux
  that can be used in a browser directly. `dist/` is ignored by git.
- Configuration for `cdnjs` autoimport from npm.

Changed:
- Clean up package.json by removing the unused browserify section;
- Remove envify and babel-runtime as they aren't being used;
- A change log :)

Fixes #112, Fixes #115. Fixes #88.