### PR TITLE
subscribe moved from Connector constructor to componentDidMount

### DIFF
--- a/src/components/createConnector.js
+++ b/src/components/createConnector.js
@@ -38,8 +38,11 @@ export default function createConnector(React) {
     constructor(props, context) {
       super(props, context);
 
-      this.unsubscribe = context.redux.subscribe(::this.handleChange);
       this.state = this.selectState(props, context);
+    }
+
+    componentDidMount() {
+      this.unsubscribe = this.context.redux.subscribe(::this.handleChange);
     }
 
     componentWillReceiveProps(nextProps) {

--- a/test/components/Connector.spec.js
+++ b/test/components/Connector.spec.js
@@ -202,5 +202,30 @@ describe('React', () => {
         );
       }).toThrow(/select/);
     });
+
+    it('does not throw error when `renderToString` is called on server', () => {
+      const { renderToString } = React;
+      const redux = createRedux({ string: stringBuilder });
+      class TestComp extends Component {
+        componentWillMount() {
+          // simulate response action on data returning
+          redux.dispatch({ type: 'APPEND', body: 'a'});
+        }
+        render() {
+          return (<div>{this.props.string}</div>);
+        }
+      }
+      const el = (
+        <Provider redux={redux}>
+          {() => (
+            <Connector select={state => ({ string: state.string })}>
+              {({ string }) => <TestComp string={string} />}
+            </Connector>
+          )}
+        </Provider>
+      );
+      expect(() => renderToString(el)).toNotThrow();
+
+    });
   });
 });


### PR DESCRIPTION
You shouldn't need to attach the Connector components to redux's setState call unless the component mounts which should only be on the browser side.  This will provide more flexibility in the way people decide to do server rendering because componentDidMount is not called on the server.