### PR TITLE
Add Slack-in Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ redux
 
 [![build status](https://img.shields.io/travis/gaearon/redux/master.svg?style=flat-square)](https://travis-ci.org/gaearon/redux)
 [![npm version](https://img.shields.io/npm/v/redux.svg?style=flat-square)](https://www.npmjs.com/package/redux)
+[![redux channel on slack](https://img.shields.io/badge/slack-redux@reactiflux-61DAFB.svg?style=flat-square)](http://www.reactiflux.com)
 
 Atomic Flux with hot reloading.  
 


### PR DESCRIPTION
Unfortunately, there's no good way to point to a specific channel on Slack so I use a link to Slack-in website instead. That's yet another reason why you should probably use Gitter instead.

I use React Blue color. Feel free to improve it.