### PR TITLE
Normalised `reduxShape` in `components`

### DIFF
--- a/src/components/createConnector.js
+++ b/src/components/createConnector.js
@@ -1,3 +1,4 @@
+import createReduxShape from './createReduxShape';
 import identity from '../utils/identity';
 import shallowEqual from '../utils/shallowEqual';
 import isPlainObject from '../utils/isPlainObject';
@@ -8,7 +9,7 @@ export default function createConnector(React) {
 
   return class Connector extends Component {
     static contextTypes = {
-      redux: PropTypes.object.isRequired
+      redux: createReduxShape(PropTypes).isRequired
     };
 
     static propTypes = {

--- a/src/components/createProvider.js
+++ b/src/components/createProvider.js
@@ -1,20 +1,18 @@
+import createReduxShape from './createReduxShape';
+
 export default function createProvider(React) {
   const { Component, PropTypes } = React;
 
-  const reduxShape = PropTypes.shape({
-    subscribe: PropTypes.func.isRequired,
-    dispatch: PropTypes.func.isRequired,
-    getState: PropTypes.func.isRequired
-  });
+  const reduxShapeIsRequired = createReduxShape(PropTypes).isRequired;
 
   return class Provider extends Component {
     static propTypes = {
-      redux: reduxShape.isRequired,
+      redux: reduxShapeIsRequired,
       children: PropTypes.func.isRequired
     };
 
     static childContextTypes = {
-      redux: reduxShape.isRequired
+      redux: reduxShapeIsRequired
     };
 
     getChildContext() {

--- a/src/components/createReduxShape.js
+++ b/src/components/createReduxShape.js
@@ -1,0 +1,7 @@
+export default function createReduxShape(PropTypes) {
+  return PropTypes.shape({
+    subscribe: PropTypes.func.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    getState: PropTypes.func.isRequired
+  });
+}


### PR DESCRIPTION
Just a simple change which also allows us to reuse `reduxShape` outside of the framework :)