### PR TITLE
Throw error on undefined value from reducer function

### DIFF
--- a/src/utils/composeReducers.js
+++ b/src/utils/composeReducers.js
@@ -5,8 +5,12 @@ export default function composeReducers(reducers) {
   const finalReducers = pick(reducers, (val) => typeof val === 'function');
 
   return function Composition(atom = {}, action) {
-    return mapValues(finalReducers, (store, key) =>
-      store(atom[key], action)
-    );
+    return mapValues(finalReducers, (reducer, key) => {
+      const state = reducer(atom[key], action);
+      if (typeof state === 'undefined') {
+        throw new Error(`Reducer ${key} returns undefined. By default reducer should return original state.`);
+      }
+      return state;
+    });
   };
 }

--- a/test/composeReducers.spec.js
+++ b/test/composeReducers.spec.js
@@ -29,5 +29,28 @@ describe('Utils', () => {
         Object.keys(reducer({}, { type: 'push' }))
       ).toEqual(['stack']);
     });
+    it('should throw an error if undefined return from reducer', () => {
+      const reducer = composeReducers({
+        stack: (state = []) => state,
+        bad: (state = [], action) => {
+          if (action.type === 'something') {
+            return state;
+          }
+        }
+      });
+      expect(() => reducer({}, {type: '@@testType'})).toThrow();
+    });
+    it('should throw an error if undefined return not by default', () => {
+      const reducer = composeReducers({
+        stack: (state = []) => state,
+        bad: (state = 1, action) => {
+          if (action.type !== 'something') {
+            return state;
+          }
+        }
+      });
+      expect(reducer({}, {type: '@@testType'})).toEqual({stack: [], bad: 1});
+      expect(() => reducer({}, {type: 'something'})).toThrow();
+    });
   });
 });


### PR DESCRIPTION
Updated composeReducers to throw error when reducer returns `undefined`. Update to #193. #191