### PR TITLE
Modify test case ID generation for reducer changing

### DIFF
--- a/test/Store.spec.js
+++ b/test/Store.spec.js
@@ -95,7 +95,7 @@ describe('Store', () => {
 
     store.dispatch(addTodo('Perhaps'));
     expect(store.getState()).toEqual([{
-      id: 2,
+      id: 3,
       text: 'Perhaps'
     }, {
       id: 1,
@@ -108,7 +108,7 @@ describe('Store', () => {
     nextStore = new Store(todos);
     store.replaceReducer(nextStore.getReducer());
     expect(store.getState()).toEqual([{
-      id: 2,
+      id: 3,
       text: 'Perhaps'
     }, {
       id: 1,
@@ -120,7 +120,7 @@ describe('Store', () => {
 
     store.dispatch(addTodo('Surely'));
     expect(store.getState()).toEqual([{
-      id: 2,
+      id: 3,
       text: 'Perhaps'
     }, {
       id: 1,
@@ -129,7 +129,7 @@ describe('Store', () => {
       id: 2,
       text: 'World'
     }, {
-      id: 3,
+      id: 4,
       text: 'Surely'
     }]);
   });

--- a/test/helpers/reducers.js
+++ b/test/helpers/reducers.js
@@ -1,10 +1,17 @@
 import { ADD_TODO } from './actionTypes';
 
+
+function id(state = []) {
+  return state.reduce((result, item) => (
+    item.id > result ? item.id : result
+  ), 0) + 1;
+}
+
 export function todos(state = [], action) {
   switch (action.type) {
   case ADD_TODO:
     return [...state, {
-      id: state.length ? state[state.length - 1].id + 1 : 1,
+      id: id(state),
       text: action.text
     }];
   default:
@@ -16,7 +23,7 @@ export function todosReverse(state = [], action) {
   switch (action.type) {
   case ADD_TODO:
     return [{
-      id: state.length ? state[0].id + 1 : 1,
+      id: id(state),
       text: action.text
     }, ...state];
   default:


### PR DESCRIPTION
While I was reading through the test cases in the #195 it caught me off guard that the IDs were being reused. This modifies the test case to not reuse IDs so you can follow the flow of where the reducer is swapped with where the next ID appears rather than only the task text string.