### PR TITLE
Remove dispatcher state copy.

### DIFF
--- a/src/Redux.js
+++ b/src/Redux.js
@@ -24,7 +24,7 @@ export default class Redux {
 
   replaceDispatcher(nextDispatcher) {
     this.dispatcher = nextDispatcher;
-    this.dispatchFn = nextDispatcher(this.state, ::this.setState);
+    this.dispatchFn = nextDispatcher(this.state, ::this.setState, ::this.getState);
   }
 
   dispatch(action) {

--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -5,16 +5,12 @@ const INIT_ACTION = {
 };
 
 export default function createDispatcher(store, middlewares = []) {
-  return function dispatcher(initialState, setState) {
-    let state = setState(store(initialState, INIT_ACTION));
-
+  return function dispatcher(initialState, setState, getState) {
+    setState(store(initialState, INIT_ACTION));
+    
     function dispatch(action) {
-      state = setState(store(state, action));
+      setState(store(getState(), action));
       return action;
-    }
-
-    function getState() {
-      return state;
     }
 
     const finalMiddlewares = typeof middlewares === 'function' ?


### PR DESCRIPTION
Why does the dispatcher have a copy of the state ?
I ran into a problem where the dispatcher state was out of sync (old) and my store was overwritten to a previous state.

I couldn't really figure out why, but only having state in redux solved the problem.