### PR TITLE
ES6 coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",
     "expect": "^1.6.0",
-    "istanbul": "^0.3.15",
+    "isparta": "^3.0.3",
     "jsdom": "~5.4.3",
     "mocha": "^2.2.5",
     "mocha-jsdom": "~0.4.0",
@@ -57,10 +57,12 @@
     "invariant": "^2.0.0"
   },
   "npmName": "redux",
-  "npmFileMap": [{
-    "basePath": "/dist/",
-    "files": [
-      "*.js"
-    ]
-  }]
+  "npmFileMap": [
+    {
+      "basePath": "/dist/",
+      "files": [
+        "*.js"
+      ]
+    }
+  ]
 }

--- a/scripts/test-cov
+++ b/scripts/test-cov
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-`npm bin`/istanbul cover `npm bin`/_mocha -- --compilers js:babel/register --recursive
+`npm bin`/babel-node `npm bin`/isparta cover `npm bin`/_mocha -- --recursive


### PR DESCRIPTION
Coverage report runs as usual:

![es6-coverage](https://cloud.githubusercontent.com/assets/175264/8636161/7896a87a-2896-11e5-9189-05655e34b21a.gif)

New shiny ES6-compatible report:

<img width="801" alt="20150712-130448" src="https://cloud.githubusercontent.com/assets/175264/8636165/a122f4ba-2896-11e5-96be-ad613dd51ec1.png">
