### PR TITLE
Update store.md to use combineReducers explicit call

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -9,18 +9,19 @@ The store has the following responsibilities:
 
 ####Initialization
 
-The simplest way to initialize the store is to call `createStore` with an object of reducer functions. The following example sets up the store for an application that has both a `counter` reducer and a `todos` reducer.
+The simplest way to initialize the store is to call `createStore` with a reducer function. The following example has both a `counter` reducer and a `todos` reducer, so they need to be combined into a single reducer using the `combineReducers` function.
 
 ```js
-import { createStore } from 'redux';
+import { createStore, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import counter from 'reducers/counter';
 import todos from 'reducers/todos';
 
-const store = createStore({counter, todos});
+const reducer = combineReducers({counter, todos});
+const store = createStore(reducer);
 ```
 
-A recommended pattern is to create the object of reducer functions from a definition file.
+A recommended pattern is to create the object passed to `combineReducers` from a definition file.
 
 ```js
 // reducers/index.js
@@ -29,10 +30,10 @@ export { default as todos } from './todos'
 ```
 
 ```js
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
+import { createStore, combineReducers } from 'redux';
 import * as reducers from './reducers/index';
 
+const reducer = combineReducer(reducers);
 const store = createStore(reducers);
 ```
 
@@ -40,18 +41,18 @@ You may optionally specify the initial state as the second argument to `createSt
 
 ```js
 // server
-const store = createStore(reducers);
+const store = createStore(reducer);
 store.dispatch(MyActionCreators.doSomething()); // fire action creators to fill the state
 const state = store.getState(); // somehow pass this state to the client
 
 // client
 const initialState = window.STATE_FROM_SERVER;
-const store = createStore(reducers, initialState);
+const store = createStore(reducer, initialState);
 ```
 
 ####Usage
 
-Store state is accessed using the `getState` method. Note that when you initialize the store by passing `createStore` an object of reducer functions, the name of each reducer becomes a top-level key on the state object.
+Store state is accessed using the `getState` method. Note that the name of each reducer in the object passed to `combineReducers` becomes a top-level key on the state object.
 
 ```js
 store.getState();
@@ -65,7 +66,7 @@ store.getState();
 // }
 ```
 
-Store state is updated by calling the `dispatch` method with an action understood by one or more reducers.
+Store state is updated by calling the `dispatch` method with an action understood by the reducer.
 
 ```js
 store.dispatch({
@@ -95,23 +96,15 @@ let unsubscribe = store.subscribe(() => console.log('state change!'));
 ```
 
 ####Advanced Intitialization
-`createStore` can be called with a single reducing function instead of an object of reducing functions. The `combineReducers` function can be used to compose multiple reducers. TODO: Real world use case?
-
-```js
-import { createStore, combineReducers } from 'redux';
-import * as reducers from './reducers/index';
-
-const combinedReducerFn = combineReducers(counter, todos);
-const store = createStore(combinedReducerFn);
-```
 
 [Middleware](middleware.md) can be set up using `applyMiddleware`.
 
 ```js
-import { createStore, applyMiddleware } from 'redux'
+import { createStore, applyMiddleware, combineReducers } from 'redux'
 import { logger, promise } from './middleware'
 import * as reducers from './reducers/index';
 
-const createWithMiddleware = applyMiddleware(logger, promise)(createStore);
-const store = createWithMiddleware(reducers);
+const reducer = combineReducers(reducers);
+const createStoreWithMiddleware = applyMiddleware(logger, promise)(createStore);
+const store = createStoreWithMiddleware(reducer);
 ```

--- a/docs/store.md
+++ b/docs/store.md
@@ -9,7 +9,7 @@ The store has the following responsibilities:
 
 ####Initialization
 
-To intialize a store you simply call `createStore` with a reducer.
+To intialize a store you simply call `createStore` with a reducer:
 
 ```js
 import { createStore } from 'redux';
@@ -18,7 +18,7 @@ import counter from './reducers/counter';
 const store = createStore(counter);
 ```
 
-A redux store works with a single reducer, but in the following example we would like to use the functionality of both the `counter` and `todos` reducers. To do this we need to somehow combine `counter` and `todos` into a single reducer. Here is one approach: 
+`createStore` intializes the store with a single reducer, but in the following example we would like to use functionality from both the `counter` and `todos` reducers. To do this we need to somehow combine `counter` and `todos` into a single reducer. Here is one approach: 
 
 ```js
 import { createStore } from 'redux';
@@ -43,7 +43,7 @@ function combinedReducer(state = initialState, action) {
 const store = createStore(combinedReducer);
 ```
 
-As combining reducers is so common there is a helper function named `combineReducers` to assist. `combineReducers` takes an object of reducers and returns them combined into a single reducer.
+As combining reducers is so common there is a helper function named `combineReducers` to assist. `combineReducers` takes an object of reducers and returns them combined into a single reducer. Here is the previous example using `combineReducers`:
 
 ```js
 import { createStore, combineReducers } from 'redux';
@@ -54,7 +54,7 @@ const reducer = combineReducers({ counter, todos });
 const store = createStore(reducer);
 ```
 
-A recommended pattern is to import the object passed to `combineReducers` from a definition file.
+A recommended pattern is to import the object passed to `combineReducers` from a definition file:
 
 ```js
 // reducers/index.js

--- a/docs/store.md
+++ b/docs/store.md
@@ -33,8 +33,8 @@ export { default as todos } from './todos'
 import { createStore, combineReducers } from 'redux';
 import * as reducers from './reducers/index';
 
-const reducer = combineReducer(reducers);
-const store = createStore(reducers);
+const reducer = combineReducers(reducers);
+const store = createStore(reducer);
 ```
 
 You may optionally specify the initial state as the second argument to `createStore`. This is useful for hydrating the state of the client to match the state of a Redux application running on the server.

--- a/docs/store.md
+++ b/docs/store.md
@@ -13,17 +13,17 @@ To intialize a store you simply call `createStore` with a reducer:
 
 ```js
 import { createStore } from 'redux';
-import counter from './reducers/counter';
+import counterReducer from './reducers/counter';
 
-const store = createStore(counter);
+const store = createStore(counterReducer);
 ```
 
-`createStore` intializes the store with a single reducer, but in the following example we would like to use functionality from both the `counter` and `todos` reducers. To do this we need to somehow combine `counter` and `todos` into a single reducer. Here is one approach: 
+`createStore` intializes the store with a single reducer, but in the following example we would like to use functionality from both the `counter` and `todos` reducers. To do this we need to somehow combine `counter` and `todos` into a single reducer. Here is one approach:
 
 ```js
 import { createStore } from 'redux';
-import counter from './reducers/counter';
-import todos from './reducers/todos';
+import counterReducer from './reducers/counter';
+import todosReducer from './reducers/todos';
 
 // set up the initial combined state
 const initialState = {
@@ -31,30 +31,44 @@ const initialState = {
   todoState: undefined
 };
  
-function combinedReducer(state = initialState, action) {
+function masterReducer(state = initialState, action) {
   // call each reducer separately
-  const counterState = counter(state.counterState, action);
-  const todoState = todos(state.todoState, action);
+  const counterState = counterReducer(state.counterState, action);
+  const todoState = todosReducer(state.todoState, action);
   
   // combine updated state created by each reducer into the new combined state
   return { counterState, todoState };
 }
 
-const store = createStore(combinedReducer);
+const store = createStore(masterReducer);
 ```
 
-As combining reducers is so common there is a helper function named `combineReducers` to assist. `combineReducers` takes an object of reducers and returns them combined into a single reducer. Here is the previous example using `combineReducers`:
+Combining reducers is very common so there is a helper function named `combineReducers` to assist. `combineReducers` takes an object of reducers and combines them into a single reducer. Here is the previous example using `combineReducers`:
 
 ```js
 import { createStore, combineReducers } from 'redux';
-import counter from './reducers/counter';
-import todos from './reducers/todos';
+import counterReducer from './reducers/counter';
+import todosReducer from './reducers/todos';
 
-const reducer = combineReducers({ counter, todos });
-const store = createStore(reducer);
+const reducers = {
+  counter: counterReducer,
+  todos: todosReducer
+}
+
+const masterReducer = combineReducers(reducers);
+const store = createStore(masterReducer);
 ```
 
-A recommended pattern is to import the object passed to `combineReducers` from a definition file:
+Note that the key of each reducer in the reducer object passed to `combineReducers` becomes a top-level key on the state object returned by the combined reducer. In the previous example, the state object returned by `masterReducer` looks like this:
+
+```js
+const state = {
+  counter: counterState,
+  todos: todosState
+};
+```
+
+A recommended pattern is to use `import *` to import an object of reducers from a definition file:
 
 ```js
 // reducers/index.js
@@ -85,7 +99,7 @@ const store = createStore(reducer, initialState);
 
 ####Usage
 
-Store state is accessed using the `getState` method. Note that the name of each reducer in the object passed to `combineReducers` becomes a top-level key on the state object.
+Store state is accessed using the `getState` method.
 
 ```js
 store.getState();

--- a/docs/store.md
+++ b/docs/store.md
@@ -3,25 +3,58 @@
 The store has the following responsibilities:
 
 * Holds application state
-* Allows access to state via the `getState` method
-* Allows state to be updated via the `dispatch` method
-* Registers listeners via the `subscribe` method
+* Allows access to state via `getState`
+* Allows state to be updated via `dispatch`
+* Registers listeners via `subscribe`
 
 ####Initialization
 
-The simplest way to initialize the store is to call `createStore` with a reducer function. The following example has both a `counter` reducer and a `todos` reducer, so they need to be combined into a single reducer using the `combineReducers` function.
+To intialize a store you simply call `createStore` with a reducer.
+
+```js
+import { createStore } from 'redux';
+import counter from './reducers/counter';
+
+const store = createStore(counter);
+```
+
+A redux store works with a single reducer, but in the following example we would like to use the functionality of both the `counter` and `todos` reducers. To do this we need to somehow combine `counter` and `todos` into a single reducer. Here is one approach: 
+
+```js
+import { createStore } from 'redux';
+import counter from './reducers/counter';
+import todos from './reducers/todos';
+
+// set up the initial combined state
+const initialState = {
+  counterState: undefined,
+  todoState: undefined
+};
+ 
+function combinedReducer(state = initialState, action) {
+  // call each reducer separately
+  const counterState = counter(state.counterState, action);
+  const todoState = todos(state.todoState, action);
+  
+  // combine updated state created by each reducer into the new combined state
+  return { counterState, todoState };
+}
+
+const store = createStore(combinedReducer);
+```
+
+As combining reducers is so common there is a helper function named `combineReducers` to assist. `combineReducers` takes an object of reducers and returns them combined into a single reducer.
 
 ```js
 import { createStore, combineReducers } from 'redux';
-import { Provider } from 'react-redux';
-import counter from 'reducers/counter';
-import todos from 'reducers/todos';
+import counter from './reducers/counter';
+import todos from './reducers/todos';
 
-const reducer = combineReducers({counter, todos});
+const reducer = combineReducers({ counter, todos });
 const store = createStore(reducer);
 ```
 
-A recommended pattern is to create the object passed to `combineReducers` from a definition file.
+A recommended pattern is to import the object passed to `combineReducers` from a definition file.
 
 ```js
 // reducers/index.js


### PR DESCRIPTION
As per commit 650f002 Remove combineReducers shortcut in favor of an explicit call