### PR TITLE
Compose applyMiddleware dispatch once.

### DIFF
--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -13,17 +13,18 @@ export default function applyMiddleware(...middlewares) {
     const store = next(...args);
     const middleware = composeMiddleware(...middlewares);
 
-    function dispatch(action) {
-      const methods = {
-        dispatch,
-        getState: store.getState
-      };
+    let composedDispatch = null;
 
-      return compose(
-        middleware(methods),
-        store.dispatch
-      )(action);
+    function dispatch(action) {
+      return composedDispatch(action);
     }
+
+    const methods = {
+      dispatch,
+      getState: store.getState
+    };
+
+    composedDispatch = compose(middleware(methods), store.dispatch);
 
     return {
       ...store,

--- a/test/utils/applyMiddleware.spec.js
+++ b/test/utils/applyMiddleware.spec.js
@@ -5,11 +5,11 @@ import { addTodo, addTodoAsync, addTodoIfEmpty } from '../helpers/actionCreators
 import { thunk } from '../helpers/middleware';
 
 describe('applyMiddleware', () => {
-  it('wraps dispatch method with middleware', () => {
+  it('wraps dispatch method with middleware once', () => {
     function test(spyOnMethods) {
-      return methods => next => action => {
+      return methods => {
         spyOnMethods(methods);
-        return next(action);
+        return next => action => next(action);
       };
     }
 
@@ -17,12 +17,16 @@ describe('applyMiddleware', () => {
     const store = applyMiddleware(test(spy), thunk)(createStore)(reducers.todos);
 
     store.dispatch(addTodo('Use Redux'));
+    store.dispatch(addTodo('Flux FTW!'));
+
+    expect(spy.calls.length).toEqual(1);
 
     expect(Object.keys(spy.calls[0].arguments[0])).toEqual([
       'dispatch',
       'getState'
     ]);
-    expect(store.getState()).toEqual([ { id: 1, text: 'Use Redux' } ]);
+
+    expect(store.getState()).toEqual([ { id: 1, text: 'Use Redux' }, { id: 2, text: 'Flux FTW!' } ]);
   });
 
   it('should pass recursive dispatches through the middleware chain', () => {


### PR DESCRIPTION
`compose(middleware(methods), store.dispatch)` was happening on each dispatch, this pr updates `applyMiddleware` to only compose the dispatch method once.