### PR TITLE
Make devtools: source-map for examples

### DIFF
--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'eval',
+  devtool: 'source-map',
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'eval',
+  devtool: 'source-map',
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',


### PR DESCRIPTION
While looking into how redux working in examples, I found it gets compiled as `eval` mode. I think enabling `source-map` is more useful for newcomers like me! :)