### PR TITLE
use function bind operator for hasOwn

### DIFF
--- a/src/utils/shallowEqualScalar.js
+++ b/src/utils/shallowEqualScalar.js
@@ -18,7 +18,7 @@ export default function shallowEqualScalar(objA, objB) {
   // Test for A's keys different from B.
   const hasOwn = Object.prototype.hasOwnProperty;
   for (let i = 0; i < keysA.length; i++) {
-    if (!hasOwn.call(objB, keysA[i])) {
+    if (!objB::hasOwn(keysA[i])) {
       return false;
     }
 


### PR DESCRIPTION
In our case, `a.call(b, ...args)` is the same as `b::a(...args)`