### PR TITLE
Allow es6 symbols to be used as action types

### DIFF
--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -11,7 +11,7 @@ import { ActionTypes } from '../createStore';
 function getErrorMessage(key: String, action: Action): string {
   var actionType = action && action.type;
   var actionName = actionType && `"${actionType.toString()}"` || 'an action';
-  
+
   return (
     `Reducer "${key}" returned undefined handling ${actionName}. ` +
     `To ignore an action, you must explicitly return the previous state.`

--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -10,8 +10,8 @@ import { ActionTypes } from '../createStore';
 
 function getErrorMessage(key: String, action: Action): string {
   var actionType = action && action.type;
-  var actionName = actionType && `"${actionType}"` || 'an action';
-
+  var actionName = actionType && `"${actionType.toString()}"` || 'an action';
+  
   return (
     `Reducer "${key}" returned undefined handling ${actionName}. ` +
     `To ignore an action, you must explicitly return the previous state.`

--- a/test/utils/combineReducers.spec.js
+++ b/test/utils/combineReducers.spec.js
@@ -83,6 +83,23 @@ describe('Utils', () => {
       );
     });
 
+    it('should allow a symbol to be used as an action type', () => {
+      const increment = Symbol('INCREMENT')
+
+      const reducer = combineReducers({
+        counter(state = 0, action) {
+          switch (action.type) {
+          case increment:
+            return state + 1;
+          default:
+            return state;
+          }
+        }
+      });
+
+      expect(reducer(0, {type: increment}).counter).toEqual(1)
+    });
+
     it('should throw an error if a reducer attempts to handle a private action', () => {
       expect(() => combineReducers({
         counter(state, action) {

--- a/test/utils/combineReducers.spec.js
+++ b/test/utils/combineReducers.spec.js
@@ -84,7 +84,7 @@ describe('Utils', () => {
     });
 
     it('should allow a symbol to be used as an action type', () => {
-      const increment = Symbol('INCREMENT')
+      const increment = Symbol('INCREMENT');
 
       const reducer = combineReducers({
         counter(state = 0, action) {
@@ -97,7 +97,7 @@ describe('Utils', () => {
         }
       });
 
-      expect(reducer(0, {type: increment}).counter).toEqual(1)
+      expect(reducer(0, {type: increment}).counter).toEqual(1);
     });
 
     it('should throw an error if a reducer attempts to handle a private action', () => {


### PR DESCRIPTION
Symbols are a good way to prevent naming collisions of action types.

However, if you attempt to use a symbol as an action type, `getErrorMessage` inside `combineReducers` will throw an error on line 13 because symbols can't be implicitly converted to a string. I can reproduce this in at least Chrome and Firefox.

Strangely enough, I could not reproduce this in the tests -- it looks like babel is implicitly converting the symbol to a string, contrary to the es6 spec as I understand it. I added a test anyway to verify the use case.

I understand Redux probably wasn't designed to be used with symbols as action types, but this seems like an easy way to add support for them.

I'm also open to other solutions or workarounds.