### PR TITLE
Remove Flow types for now

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,8 +1,3 @@
-/* @flow */
-/*eslint-disable */
-import type { State, Reducer, Action, IntermediateAction, Store } from './index';
-/*eslint-enable */
-
 import invariant from 'invariant';
 import isPlainObject from './utils/isPlainObject';
 
@@ -13,10 +8,7 @@ export var ActionTypes = {
   INIT: '@@redux/INIT'
 };
 
-export default function createStore(
-  reducer: Reducer,
-  initialState: State
-): Store {
+export default function createStore(reducer, initialState) {
   invariant(
     typeof reducer === 'function',
     'Expected the reducer to be a function.'
@@ -30,7 +22,7 @@ export default function createStore(
     return currentState;
   }
 
-  function subscribe(listener: Function) {
+  function subscribe(listener) {
     listeners.push(listener);
 
     return function unsubscribe() {
@@ -39,7 +31,7 @@ export default function createStore(
     };
   }
 
-  function dispatch(action: Action) {
+  function dispatch(action) {
     invariant(
       isPlainObject(action),
       'Actions must be plain objects. Use custom middleware for async actions.'
@@ -54,7 +46,7 @@ export default function createStore(
     return currentReducer;
   }
 
-  function replaceReducer(nextReducer: Reducer) {
+  function replaceReducer(nextReducer) {
     currentReducer = nextReducer;
     dispatch({ type: ActionTypes.INIT });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,3 @@
-/* @flow */
-
-export type State = any;
-export type Action = Object;
-export type IntermediateAction = any;
-export type Dispatch = (a: Action | IntermediateAction) => any;
-export type Reducer<S, A> = (state: S, action: A) => S;
-export type ActionCreator = (...args: any) => Action | IntermediateAction;
-
-export type MiddlewareArgs = {
-  dispatch: Dispatch;
-  getState: () => State;
-};
-
-export type Middleware = (args: MiddlewareArgs) =>
-  (next: Dispatch) =>
-  Dispatch;
-
-export type Store = {
-  dispatch: Dispatch;
-  getState: () => State;
-  getReducer: () => Reducer;
-  replaceReducer: (nextReducer: Reducer) => void;
-  subscribe: (listener: () => void) => () => void;
-};
-
-export type CreateStore = (
-  reducer: Reducer,
-  initialState: State
-) => Store;
-
-export type HigherOrderStore = (
-  next: CreateStore
-) => CreateStore;
-
 import createStore from './createStore';
 import compose from './utils/compose';
 import combineReducers from './utils/combineReducers';

--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -1,11 +1,3 @@
-/* @flow */
-/*eslint-disable */
-import type {
-  Dispatch, Middleware, Reducer, State,
-  Store, CreateStore, HigherOrderStore
-} from '../index';
-/*eslint-enable */
-
 import compose from './compose';
 import composeMiddleware from './composeMiddleware';
 
@@ -16,10 +8,8 @@ import composeMiddleware from './composeMiddleware';
  * @param {...Function} ...middlewares
  * @return {Function} A higher-order store
  */
-export default function applyMiddleware(
-  ...middlewares: Array<Middleware>
-): HigherOrderStore {
-  return (next: CreateStore) => (reducer: Reducer, initialState: State) => {
+export default function applyMiddleware(...middlewares) {
+  return (next) => (reducer, initialState) => {
     var store = next(reducer, initialState);
     var middleware = composeMiddleware(...middlewares);
     var composedDispatch = () => {};

--- a/src/utils/bindActionCreators.js
+++ b/src/utils/bindActionCreators.js
@@ -1,14 +1,6 @@
-/* @flow */
-/*eslint-disable */
-import type { Dispatch } from '../index';
-/*eslint-enable */
-
 import mapValues from '../utils/mapValues';
 
-export default function bindActionCreators(
-  actionCreators: Object,
-  dispatch: Dispatch
-): Object {
+export default function bindActionCreators(actionCreators, dispatch) {
   return mapValues(actionCreators, actionCreator =>
     (...args) => dispatch(actionCreator(...args))
   );

--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -1,14 +1,9 @@
-/* @flow */
-/*eslint-disable */
-import type { Action, State, Reducer } from '../index';
-/*eslint-enable */
-
 import mapValues from '../utils/mapValues';
 import pick from '../utils/pick';
 import invariant from 'invariant';
 import { ActionTypes } from '../createStore';
 
-function getErrorMessage(key: String, action: Action): string {
+function getErrorMessage(key, action) {
   var actionType = action && action.type;
   var actionName = actionType && `"${actionType}"` || 'an action';
 
@@ -18,7 +13,7 @@ function getErrorMessage(key: String, action: Action): string {
   );
 }
 
-export default function combineReducers(reducers: Object): Reducer {
+export default function combineReducers(reducers) {
   var finalReducers = pick(reducers, (val) => typeof val === 'function');
 
   Object.keys(finalReducers).forEach(key => {
@@ -43,7 +38,7 @@ export default function combineReducers(reducers: Object): Reducer {
     );
   });
 
-  return function composition(state: State = {}, action: Action): State {
+  return function composition(state = {}, action) {
     return mapValues(finalReducers, (reducer, key) => {
       var newState = reducer(state[key], action);
       invariant(

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -1,10 +1,8 @@
-/* @flow */
-
 /**
  * Composes functions from left to right
  * @param  {...Function} funcs - Functions to compose
  * @return {Function}
  */
-export default function compose(...funcs: Array<Function>): Function {
+export default function compose(...funcs) {
   return funcs.reduceRight((composed, f) => f(composed));
 }

--- a/src/utils/composeMiddleware.js
+++ b/src/utils/composeMiddleware.js
@@ -1,8 +1,3 @@
-/* @flow */
-/*eslint-disable */
-import type { Dispatch, Middleware, MiddlewareArgs } from '../index';
-/*eslint-enable */
-
 import compose from './compose';
 
 /**
@@ -10,12 +5,9 @@ import compose from './compose';
  * @param  {...Function} middlewares
  * @return {Function}
  */
-export default function composeMiddleware(
-  ...middlewares: Array<Middleware>
-): Middleware {
-  return (args: MiddlewareArgs) => (next: Dispatch) => {
+export default function composeMiddleware(...middlewares) {
+  return args => rawDispatch => {
     var dispatchChain = middlewares.map(middleware => middleware(args));
-    dispatchChain.push(next);
-    return compose.apply(null, dispatchChain);
+    return compose(...dispatchChain, rawDispatch);
   };
 }

--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -1,6 +1,4 @@
-/* @flow */
-
-export default function isPlainObject(obj: Object): boolean {
+export default function isPlainObject(obj) {
   if (!obj) {
     return false;
   }

--- a/src/utils/mapValues.js
+++ b/src/utils/mapValues.js
@@ -1,6 +1,4 @@
-/* @flow */
-
-export default function mapValues(obj: Object, fn: Function): Object {
+export default function mapValues(obj, fn) {
   return Object.keys(obj).reduce((result, key) => {
     result[key] = fn(obj[key], key);
     return result;

--- a/src/utils/pick.js
+++ b/src/utils/pick.js
@@ -1,6 +1,4 @@
-/* @flow */
-
-export default function pick(obj: Object, fn: Function): Object {
+export default function pick(obj, fn) {
   return Object.keys(obj).reduce((result, key) => {
     if (fn(obj[key])) {
       result[key] = obj[key];


### PR DESCRIPTION
I decided in favor of *not* shipping Flow types in 1.0.
This commit just strips types from the current Flow-friendly codebase (initially worked on in #254).

We will not use features unsupported by Flow (such as `let` or `const`) from now on so it's easy to gradually add Flow types later.

The reason I'm removing them is **they're too naive** and I don't want them to be perceived as the public API (at least not yet). I am ready to add Flow when [cases like this](https://github.com/gaearon/redux/issues/290) are solved. Adding them now is confusing because, for #290 to work, different (more polymorphic) signatures are needed. For example, `Store` type should be parameterized by `<MyState, MyAction>` instead of `any` types in the current annotations.