### PR TITLE
Warn if the initial state shape doesn't match the reducer names

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "webpack-dev-server": "^1.8.2"
   },
   "dependencies": {
-    "invariant": "^2.0.0"
+    "invariant": "^2.0.0",
+    "warning": "^2.0.0"
   },
   "npmName": "redux",
   "npmFileMap": [


### PR DESCRIPTION
Ok, not super happy with this but it is a start.

* I have written tests for verifyStateShape, but I couldn't think of a neat way to test the code in createStore so there is currently a hole in the test coverage.
* I don't really like the function name verifyStateShape. Is stateShapeWarning better?
* I haven't used an external warning module. Would it be a good idea? I'm currently just calling console.warn.

Happy to take some direction on this.