### PR TITLE
fix id assignment in example

### DIFF
--- a/examples/todomvc/stores/todos.js
+++ b/examples/todomvc/stores/todos.js
@@ -10,7 +10,7 @@ export default function todos(state = initialState, action) {
   switch (action.type) {
   case ADD_TODO:
     return [{
-      id: (state.length === 0) ? 0 : state[0].id + 1,
+      id: state.length,
       marked: false,
       text: action.text
     }, ...state];


### PR DESCRIPTION
The todo example assumes that the earliest item in the item array is the most recent, which is perfectly fine when the example is used as presented.  However, once you start experimenting (retrieving items from elsewhere, adding sync from a server etc), this may no longer be the case. Since React uses the `id` to assign item keys, this becomes another thing to debug as one is familiarizing oneself with redux's behaviour. The small change proposed below makes `id` assignment simpler and consequently easier to understand.