### PR TITLE
Allow `bindActionCreators` to be used with function as actionCreator

### DIFF
--- a/src/utils/bindActionCreators.js
+++ b/src/utils/bindActionCreators.js
@@ -1,13 +1,18 @@
 import mapValues from '../utils/mapValues';
 
+function bindActionCreator(actionCreator, dispatch) {
+  return (...args) => dispatch(actionCreator(...args));
+}
+
 /**
  * Turns an object whose values are action creators, into an object with the
  * same keys, but with every function wrapped into a `dispatch` call so they
  * may be invoked directly. This is just a convenience method, as you can call
  * `store.dispatch(MyActionCreators.doSomething())` yourself just fine.
  *
- * @param {Object} actionCreators An object whose values are action creator
- * functions. One handy way to obtain it is to use ES6 `import * as` syntax.
+ * @param {Object|Function} actionCreators An object whose values are action
+ * creator functions. One handy way to obtain it is to use ES6 `import * as`
+ * syntax. It also supports binding only a single function.
  *
  * @param {Function} dispatch The `dispatch` function available on your Redux
  * store.
@@ -16,7 +21,11 @@ import mapValues from '../utils/mapValues';
  * action creator wrapped into the `dispatch` call.
  */
 export default function bindActionCreators(actionCreators, dispatch) {
+  if (typeof actionCreators === 'function') {
+    return bindActionCreator(actionCreators, dispatch);
+  }
+
   return mapValues(actionCreators, actionCreator =>
-    (...args) => dispatch(actionCreator(...args))
+    bindActionCreator(actionCreator, dispatch)
   );
 }

--- a/test/utils/bindActionCreators.spec.js
+++ b/test/utils/bindActionCreators.spec.js
@@ -26,4 +26,15 @@ describe('bindActionCreators', () => {
       { id: 1, text: 'Hello' }
     ]);
   });
+
+  it('should support wrapping a single function only', () => {
+    const actionCreator = actionCreators.addTodo;
+    const boundActionCreator = bindActionCreators(actionCreator, store.dispatch);
+
+    const action = boundActionCreator('Hello');
+    expect(action).toEqual(actionCreator('Hello'));
+    expect(store.getState()).toEqual([
+      { id: 1, text: 'Hello' }
+    ]);
+  });
 });


### PR DESCRIPTION
With this change you can use `bindActionCreators` to either bind a object of actionCreator functions to dispatch or only a single actionCreator directly.

```js
import { bindActionCreators } from 'redux';
import { addTodo } from './actions/todoActions';

const boundAddTodo = bindActionCreators(addTodo, dispatch);
boundAddTodo('Hello');
```