### PR TITLE
Add script to help travis build all examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "iojs"
+script:
+  - npm test
+  - npm run build:examples
+

--- a/examples/buildAll.js
+++ b/examples/buildAll.js
@@ -1,0 +1,31 @@
+/**
+ * Runs an ordered set of commands within each of the build directories.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+var exampleDirs = fs.readdirSync(__dirname).filter((file) => {
+  return fs.statSync(path.join(__dirname, file)).isDirectory();
+});
+
+// Ordering is important here. `npm install` must come first.
+var cmdArgs = [
+  { cmd: 'npm', args: ['install'] },
+  { cmd: 'webpack', args: ['index.js'] }
+];
+
+for (let dir of exampleDirs) {
+  let opts = {
+    cwd: path.join(__dirname, dir),
+    stdio: 'inherit'
+  };
+
+  for (let cmdArg of cmdArgs) {
+    let result = spawnSync(cmdArg.cmd, cmdArg.args, opts);
+    if (result.status !== 0) {
+      throw new Error('Building examples exited with non-zero');
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "npm run lint && npm run test",
     "build:lib": "babel src --out-dir lib",
     "build:umd": "webpack src/index.js dist/redux.js && NODE_ENV=production webpack src/index.js dist/redux.min.js",
+    "build:examples": "babel-node examples/buildAll.js",
     "build": "npm run build:lib && npm run build:umd",
     "preversion": "npm run clean && npm run check",
     "version": "npm run build",


### PR DESCRIPTION
Doesn't run the tests yet, but can easily do so. If this looks good, Travis will need to run `npm build:examples`