### PR TITLE
Dispatch data from the Call API Middleware example

### DIFF
--- a/docs/recipes/ReducingBoilerplate.md
+++ b/docs/recipes/ReducingBoilerplate.md
@@ -375,9 +375,11 @@ function callAPIMiddleware({ dispatch, getState }) {
 
       return callAPI().then(
         response => dispatch(Object.assign({}, payload, {
+          response: response,
           type: successType
         })),
         error => dispatch(Object.assign({}, payload, {
+          error: error,
           type: failureType
         }))
       );


### PR DESCRIPTION
Just a small change, but going over this example, the data returned from the API call isnt being dispatched :)