### PR TITLE
add jsnext:main, include src for next gen bundling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-src
 examples

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.12.0",
   "description": "Atomic Flux with hot reloading",
   "main": "lib/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "browser": "scripts/browser",
     "build": "scripts/build",


### PR DESCRIPTION
As title says, [read more here](https://github.com/rollup/rollup/wiki/jsnext:main).