### PR TITLE
Bind warning

### DIFF
--- a/src/utils/bindActionCreators.js
+++ b/src/utils/bindActionCreators.js
@@ -1,3 +1,4 @@
+import invariant from 'invariant';
 import mapValues from '../utils/mapValues';
 
 function bindActionCreator(actionCreator, dispatch) {
@@ -25,7 +26,15 @@ export default function bindActionCreators(actionCreators, dispatch) {
     return bindActionCreator(actionCreators, dispatch);
   }
 
+  invariant(
+    typeof actionCreators === 'object' && actionCreators != null,
+    'bindActionCreators expected an object or a function, instead received %s. ' +
+    'Did you write "import ActionCreators from" instead of "import * as ActionCreators from"?',
+    typeof actionCreators
+  );
+
   return mapValues(actionCreators, actionCreator =>
     bindActionCreator(actionCreator, dispatch)
   );
 }
+

--- a/test/utils/bindActionCreators.spec.js
+++ b/test/utils/bindActionCreators.spec.js
@@ -37,4 +37,31 @@ describe('bindActionCreators', () => {
       { id: 1, text: 'Hello' }
     ]);
   });
+
+  it('should throw an invariant violation for an undefined actionCreator', () => {
+    expect(() => {
+      bindActionCreators(undefined, store.dispatch);
+    }).toThrow(
+      'bindActionCreators expected an object or a function, instead received undefined. ' +
+      'Did you write "import ActionCreators from" instead of "import * as ActionCreators from"?'
+    );
+  });
+
+  it('should throw an invariant violation for a null actionCreator', () => {
+    expect(() => {
+      bindActionCreators(null, store.dispatch);
+    }).toThrow(
+      'bindActionCreators expected an object or a function, instead received null. ' +
+      'Did you write "import ActionCreators from" instead of "import * as ActionCreators from"?'
+    );
+  });
+
+  it('should throw an invariant violation for a primitive actionCreator', () => {
+    expect(() => {
+      bindActionCreators('string', store.dispatch);
+    }).toThrow(
+      'bindActionCreators expected an object or a function, instead received string. ' +
+      'Did you write "import ActionCreators from" instead of "import * as ActionCreators from"?'
+    );
+  });
 });


### PR DESCRIPTION
This adds invariant warning support to `bindActionCreators` as per issue #407.