### PR TITLE
add jsnext:main in package.json for next gen bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-rc",
   "description": "Atomic Flux with hot reloading",
   "main": "lib/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "clean": "rimraf lib dist coverage",
     "lint": "eslint src test examples",


### PR DESCRIPTION
As per title, [see here for more info on jsnext:main](https://github.com/rollup/rollup/wiki/jsnext:main).