### PR TITLE
fixed readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ cd redux
 Run the Counter example:
 
 ```
+cd redux/
+npm install
 cd redux/examples/counter
 npm install
 npm start


### PR DESCRIPTION
Added npm install to root path,
Someone on slack was having problems not being able to run the examples without. Readme wasn't clear if you are only running examples. Not even sure if after docs release this doc will make much sense tho