### PR TITLE
add edit-link plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,0 +1,10 @@
+{
+  "gitbook": "2.2.0",
+  "plugins": ["edit-link"],
+  "pluginsConfig": {
+    "edit-link": {
+      "base": "https://github.com/gaearon/redux/tree/rewrite-docs-again",
+      "label": "Edit This Page"
+    }
+  }
+}


### PR DESCRIPTION
RE: #345 (edit page)

to install the plugin you need to run:
`gitbook install`  

it runs whatever is in `book.json`, so now the Gitbook version can also be specified in there