### PR TITLE
Update counter example to recent react-redux

### DIFF
--- a/examples/counter/containers/CounterApp.js
+++ b/examples/counter/containers/CounterApp.js
@@ -1,23 +1,16 @@
-import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Counter from '../components/Counter';
 import * as CounterActions from '../actions/CounterActions';
 
-class CounterApp extends Component {
-  render() {
-    const { counter, dispatch } = this.props;
-    return (
-      <Counter counter={counter}
-               {...bindActionCreators(CounterActions, dispatch)} />
-    );
+function mapStateToProps(state) {
+  return {
+    counter: state.counter
   }
 }
 
-function select(state) {
-  return {
-    counter: state.counter
-  };
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(CounterActions, dispatch);
 }
 
-export default connect(select)(CounterApp);
+export default connect(mapStateToProps, mapDispatchToProps)(Counter);

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/gaearon/redux#readme",
   "dependencies": {
     "react": "^0.13.3",
-    "react-redux": "^0.4.0",
+    "react-redux": "^0.8.0",
     "redux": "^1.0.0-rc",
     "redux-thunk": "^0.1.0"
   },


### PR DESCRIPTION
Update `Counter` example to use the most recent version of [react-redux](https://github.com/gaearon/react-redux).

Separate `Counter` into "smart" and "dumb" components per [smart / dumb](https://github.com/gaearon/react-redux#dumb-component-is-unaware-of-redux)