### PR TITLE
Fixes #461 - Copy listeners array, so subscribes can't affect the loop.

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -106,7 +106,7 @@ export default function createStore(reducer, initialState) {
       isDispatching = false;
     }
 
-    listeners.forEach(listener => listener());
+    listeners.slice().forEach(listener => listener());
     return action;
   }
 

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -204,6 +204,28 @@ describe('createStore', () => {
     expect(listenerB.calls.length).toBe(2);
   });
 
+  it('should support removing a subscription within a subscription', () => {
+    const store = createStore(reducers.todos);
+    const listenerA = expect.createSpy(() => {});
+    const listenerB = expect.createSpy(() => {});
+    const listenerC = expect.createSpy(() => {});
+
+    store.subscribe(listenerA);
+    const unSubB = store.subscribe(() => {
+      listenerB();
+      unSubB();
+    });
+    store.subscribe(listenerC);
+
+    store.dispatch({});
+    store.dispatch({});
+
+    expect(listenerA.calls.length).toBe(2);
+    expect(listenerB.calls.length).toBe(1);
+    expect(listenerC.calls.length).toBe(2);
+
+  });
+
   it('should provide an up-to-date state when a subscriber is notified', done => {
     const store = createStore(reducers.todos);
     store.subscribe(() => {


### PR DESCRIPTION
Unsubscribing during a dispatch would change the listeners array.
However that causes the next listener not to fire.

Fixes #461 