### PR TITLE
Fix syntax error in Object.assign in real world example

### DIFF
--- a/examples/real-world/middleware/api.js
+++ b/examples/real-world/middleware/api.js
@@ -41,11 +41,11 @@ function callApi(endpoint, schema) {
       const camelizedJson = camelizeKeys(json);
       const nextPageUrl = getNextPageUrl(response) || undefined;
 
-      return Object.assign({
+      return Object.assign(
         {},
         normalize(camelizedJson, schema),
         nextPageUrl
-      });
+      );
     });
 }
 


### PR DESCRIPTION
Wasn't able to build example.